### PR TITLE
PR-001: Initialize Rust workspace with minimal crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Rust
+/target/
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Murmuration cache
+.murmur/

--- a/.murmur-session-notes.md
+++ b/.murmur-session-notes.md
@@ -1,0 +1,32 @@
+# Session Notes - Murmuration Development
+
+## Development Strategy
+
+1. **Create GitHub issues first** for Phases 1-7 (bootstrap phases) with proper linking/dependencies
+2. **Use stacked PRs** - each PR builds on the previous, merged in order
+3. **After Phase 2 is ready**, start using Murmuration to build itself
+4. **Iterate** on remaining phases using Murmuration
+
+## PR Strategy: Stacked PRs
+
+- Create branches that stack: `phase1/pr-001` → `phase1/pr-002` → `phase1/pr-003` etc.
+- Each PR targets the previous PR's branch (not main directly)
+- Merge in order to main
+- This allows parallel review while maintaining dependencies
+
+## Bootstrap Phases to Create Issues For
+
+- Phase 1: Minimal CLI + Agent Spawning (PR-001 to PR-005)
+- Phase 2: Git Worktrees Smart (PR-006 to PR-011) ← START USING MURMURATION HERE
+- Phase 3: GitHub Integration + Dependencies (PR-012 to PR-018)
+- Phase 3b: Plan Import to GitHub (PR-019 to PR-022)
+- Phase 4: Agent Types + Prompts (PR-023 to PR-029)
+- Phase 5: TDD Workflow Red-Green (PR-030 to PR-034)
+- Phase 6: Review Agents at Each Phase (PR-035 to PR-040)
+- Phase 7: Coordinator Agent (PR-041 to PR-046)
+
+## Current Status
+
+- Design phase: COMPLETE
+- GitHub repo: https://github.com/jmalicki-ai-slop/ai-agent-murmuration
+- Next: Create GitHub issues for bootstrap phases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,34 @@
+[workspace]
+resolver = "2"
+members = [
+    "murmur-core",
+    "murmur-cli",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/jmalicki-ai-slop/ai-agent-murmuration"
+
+[workspace.dependencies]
+# Async runtime
+tokio = { version = "1.41", features = ["full"] }
+
+# CLI
+clap = { version = "4.5", features = ["derive"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+thiserror = "2.0"
+anyhow = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Internal crates
+murmur-core = { path = "murmur-core" }

--- a/murmur-cli/Cargo.toml
+++ b/murmur-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "murmur-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CLI for Murmuration multi-agent orchestration"
+
+[[bin]]
+name = "murmur"
+path = "src/main.rs"
+
+[dependencies]
+murmur-core.workspace = true
+tokio.workspace = true
+clap.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -1,0 +1,53 @@
+//! Murmur CLI - Command line interface for Murmuration
+//!
+//! Multi-agent orchestration for software development with Claude Code.
+
+use clap::Parser;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+/// Murmuration: Multi-agent orchestration for software development
+#[derive(Parser, Debug)]
+#[command(name = "murmur")]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Enable verbose output
+    #[arg(short, long, global = true)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Parser, Debug)]
+enum Commands {
+    /// Show version information
+    Version,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+
+    if cli.verbose {
+        tracing::info!("Verbose mode enabled");
+    }
+
+    match cli.command {
+        Some(Commands::Version) => {
+            println!("murmur {}", env!("CARGO_PKG_VERSION"));
+        }
+        None => {
+            println!("Murmuration - Multi-agent orchestration for software development");
+            println!();
+            println!("Use --help for usage information");
+        }
+    }
+
+    Ok(())
+}

--- a/murmur-core/Cargo.toml
+++ b/murmur-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "murmur-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Core library for Murmuration multi-agent orchestration"
+
+[dependencies]
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true

--- a/murmur-core/src/error.rs
+++ b/murmur-core/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for Murmuration
+
+use thiserror::Error;
+
+/// Result type alias for Murmuration operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error type for Murmuration operations
+#[derive(Error, Debug)]
+pub enum Error {
+    /// IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization/deserialization error
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Agent execution error
+    #[error("Agent error: {0}")]
+    Agent(String),
+
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// Generic error with message
+    #[error("{0}")]
+    Other(String),
+}

--- a/murmur-core/src/lib.rs
+++ b/murmur-core/src/lib.rs
@@ -1,0 +1,8 @@
+//! Murmur Core - Core library for Murmuration multi-agent orchestration
+//!
+//! This crate provides the core functionality for orchestrating multiple
+//! AI agents working collaboratively on software development tasks.
+
+pub mod error;
+
+pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

Initialize the Rust workspace with the minimal crate structure needed for bootstrap.

- Create workspace with `murmur-core` and `murmur-cli` crates
- Set up workspace dependencies (tokio, clap, serde, thiserror, tracing)
- Add basic error types in murmur-core
- Add minimal CLI skeleton with --help and version command

## Testing

```bash
cargo build  # ✅ Builds successfully
cargo test   # ✅ Tests pass (no tests yet)
./target/debug/murmur --help  # ✅ Shows help
```

## Closes

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)