### PR TITLE
PR-012: Add GitHub API client with octocrab

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "murmur-core",
     "murmur-cli",
+    "murmur-github",
 ]
 
 [workspace.package]
@@ -39,5 +40,9 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# GitHub API
+octocrab = "0.41"
+
 # Internal crates
 murmur-core = { path = "murmur-core" }
+murmur-github = { path = "murmur-github" }

--- a/murmur-github/Cargo.toml
+++ b/murmur-github/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "murmur-github"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "GitHub integration for Murmuration multi-agent orchestration"
+
+[dependencies]
+murmur-core.workspace = true
+octocrab.workspace = true
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url.workspace = true

--- a/murmur-github/src/client.rs
+++ b/murmur-github/src/client.rs
@@ -1,0 +1,195 @@
+//! GitHub API client using octocrab
+
+use crate::{Error, Result};
+use octocrab::Octocrab;
+use tracing::{debug, info};
+
+/// GitHub API client for repository operations
+pub struct GitHubClient {
+    client: Octocrab,
+    owner: String,
+    repo: String,
+}
+
+impl GitHubClient {
+    /// Create a new GitHub client for the specified repository
+    ///
+    /// Requires GITHUB_TOKEN environment variable to be set.
+    pub fn new(owner: impl Into<String>, repo: impl Into<String>) -> Result<Self> {
+        let owner = owner.into();
+        let repo = repo.into();
+
+        let token = std::env::var("GITHUB_TOKEN").map_err(|_| {
+            Error::Auth("GITHUB_TOKEN environment variable not set".to_string())
+        })?;
+
+        let client = Octocrab::builder()
+            .personal_token(token)
+            .build()
+            .map_err(|e| Error::Auth(format!("Failed to create GitHub client: {}", e)))?;
+
+        info!(owner = %owner, repo = %repo, "Created GitHub client");
+
+        Ok(Self {
+            client,
+            owner,
+            repo,
+        })
+    }
+
+    /// Create a GitHub client from a repository URL
+    ///
+    /// Supports formats:
+    /// - owner/repo
+    /// - https://github.com/owner/repo
+    /// - git@github.com:owner/repo.git
+    pub fn from_url(url: &str) -> Result<Self> {
+        let (owner, repo) = parse_github_url(url)?;
+        Self::new(owner, repo)
+    }
+
+    /// Get the repository owner
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    /// Get the repository name
+    pub fn repo(&self) -> &str {
+        &self.repo
+    }
+
+    /// Get the underlying octocrab client
+    pub fn client(&self) -> &Octocrab {
+        &self.client
+    }
+
+    /// Test the connection by fetching repository info
+    pub async fn test_connection(&self) -> Result<()> {
+        debug!(
+            owner = %self.owner,
+            repo = %self.repo,
+            "Testing GitHub connection"
+        );
+
+        self.client
+            .repos(&self.owner, &self.repo)
+            .get()
+            .await
+            .map_err(|e| match e {
+                octocrab::Error::GitHub { source, .. } => {
+                    if source.message.contains("Not Found") {
+                        Error::Other(format!(
+                            "Repository {}/{} not found or not accessible",
+                            self.owner, self.repo
+                        ))
+                    } else if source.message.contains("Bad credentials") {
+                        Error::Auth("Invalid GitHub token".to_string())
+                    } else {
+                        Error::Api(octocrab::Error::GitHub {
+                            source,
+                            backtrace: std::backtrace::Backtrace::capture(),
+                        })
+                    }
+                }
+                other => Error::Api(other),
+            })?;
+
+        info!("GitHub connection successful");
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for GitHubClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitHubClient")
+            .field("owner", &self.owner)
+            .field("repo", &self.repo)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Parse a GitHub URL into owner and repo
+fn parse_github_url(url: &str) -> Result<(String, String)> {
+    // Handle shorthand: owner/repo
+    if !url.contains(':') && !url.contains('/') {
+        return Err(Error::Parse(format!(
+            "Invalid repository format: {}. Expected owner/repo",
+            url
+        )));
+    }
+
+    if !url.contains("://") && !url.contains('@') {
+        // Simple owner/repo format
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() == 2 {
+            return Ok((parts[0].to_string(), parts[1].trim_end_matches(".git").to_string()));
+        }
+        return Err(Error::Parse(format!(
+            "Invalid repository format: {}. Expected owner/repo",
+            url
+        )));
+    }
+
+    // Handle HTTPS URL: https://github.com/owner/repo
+    if url.starts_with("https://") || url.starts_with("http://") {
+        let url = url::Url::parse(url).map_err(|e| Error::Parse(e.to_string()))?;
+        let path = url.path().trim_start_matches('/').trim_end_matches(".git");
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() >= 2 {
+            return Ok((parts[0].to_string(), parts[1].to_string()));
+        }
+        return Err(Error::Parse(format!("Invalid GitHub URL path: {}", path)));
+    }
+
+    // Handle SSH URL: git@github.com:owner/repo.git
+    if url.starts_with("git@") {
+        if let Some(path) = url.split(':').nth(1) {
+            let path = path.trim_end_matches(".git");
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 2 {
+                return Ok((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+        return Err(Error::Parse(format!("Invalid SSH URL: {}", url)));
+    }
+
+    Err(Error::Parse(format!("Unrecognized URL format: {}", url)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_shorthand() {
+        let (owner, repo) = parse_github_url("owner/repo").unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_https_url() {
+        let (owner, repo) = parse_github_url("https://github.com/owner/repo").unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_https_url_with_git_suffix() {
+        let (owner, repo) = parse_github_url("https://github.com/owner/repo.git").unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_ssh_url() {
+        let (owner, repo) = parse_github_url("git@github.com:owner/repo.git").unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        assert!(parse_github_url("invalid").is_err());
+    }
+}

--- a/murmur-github/src/error.rs
+++ b/murmur-github/src/error.rs
@@ -1,0 +1,48 @@
+//! Error types for GitHub operations
+
+use thiserror::Error;
+
+/// Result type for GitHub operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur during GitHub operations
+#[derive(Error, Debug)]
+pub enum Error {
+    /// GitHub API error
+    #[error("GitHub API error: {0}")]
+    Api(#[from] octocrab::Error),
+
+    /// Authentication error
+    #[error("GitHub authentication error: {0}")]
+    Auth(String),
+
+    /// Missing environment variable
+    #[error("Missing environment variable: {0}")]
+    MissingEnv(String),
+
+    /// Issue not found
+    #[error("Issue #{0} not found")]
+    IssueNotFound(u64),
+
+    /// Pull request not found
+    #[error("Pull request #{0} not found")]
+    PrNotFound(u64),
+
+    /// Rate limit exceeded
+    #[error("GitHub rate limit exceeded, resets at {0}")]
+    RateLimited(String),
+
+    /// Parse error
+    #[error("Parse error: {0}")]
+    Parse(String),
+
+    /// Other error
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<std::env::VarError> for Error {
+    fn from(err: std::env::VarError) -> Self {
+        Error::MissingEnv(err.to_string())
+    }
+}

--- a/murmur-github/src/lib.rs
+++ b/murmur-github/src/lib.rs
@@ -1,0 +1,10 @@
+//! Murmur GitHub - GitHub integration for Murmuration
+//!
+//! This crate provides GitHub API access for reading issues, managing PRs,
+//! and tracking dependencies between work items.
+
+mod client;
+mod error;
+
+pub use client::GitHubClient;
+pub use error::{Error, Result};


### PR DESCRIPTION
## Summary
- Adds `murmur-github` crate for GitHub API integration
- Implements `GitHubClient` with octocrab for authenticated API access
- Supports GITHUB_TOKEN environment variable authentication
- Parses repository URLs (owner/repo, HTTPS, SSH formats)
- Includes connection testing for credential validation
- Custom error types for GitHub-specific failures

## Test plan
- [x] Unit tests for URL parsing (5 tests)
- [x] All 30 tests pass
- [ ] Manual testing with `GITHUB_TOKEN` set

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)