### PR TITLE
PR-018: Add work command with dependency checking

### DIFF
--- a/murmur-cli/src/commands/mod.rs
+++ b/murmur-cli/src/commands/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod issue;
 pub mod run;
+pub mod work;
 pub mod worktree;
 
 pub use issue::IssueArgs;
 pub use run::RunArgs;
+pub use work::WorkArgs;
 pub use worktree::WorktreeArgs;

--- a/murmur-cli/src/commands/work.rs
+++ b/murmur-cli/src/commands/work.rs
@@ -1,0 +1,279 @@
+//! Work command - start working on an issue with dependency checking
+
+use clap::Args;
+use murmur_core::{
+    AgentSpawner, BranchingOptions, Config, GitRepo, OutputStreamer, PrintHandler,
+    WorktreeMetadata, WorktreeOptions,
+};
+use murmur_github::{DependencyStatus, GitHubClient, IssueDependencies, IssueState};
+
+/// Work on a GitHub issue
+#[derive(Args, Debug)]
+pub struct WorkArgs {
+    /// Issue number to work on
+    pub issue: u64,
+
+    /// Repository (owner/repo format, uses current repo if not specified)
+    #[arg(short, long)]
+    pub repo: Option<String>,
+
+    /// Skip dependency checking
+    #[arg(short, long)]
+    pub force: bool,
+
+    /// Custom prompt to send to the agent (uses issue description if not provided)
+    #[arg(short, long)]
+    pub prompt: Option<String>,
+
+    /// Don't start the agent, just create the worktree
+    #[arg(long)]
+    pub no_agent: bool,
+}
+
+impl WorkArgs {
+    /// Execute the work command
+    pub async fn execute(
+        &self,
+        verbose: bool,
+        config: &Config,
+        repo: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let repo_str = self.repo.as_deref().or(repo).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No repository specified. Use --repo owner/repo or run from a git repository"
+            )
+        })?;
+
+        let client =
+            GitHubClient::from_url(repo_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+        println!(
+            "Working on issue #{} in {}/{}",
+            self.issue,
+            client.owner(),
+            client.repo()
+        );
+        println!();
+
+        // Fetch the issue
+        let issue = client.get_issue(self.issue).await?;
+
+        println!("#{}: {}", issue.number, issue.title);
+        println!();
+
+        // Check dependencies unless --force
+        if !self.force {
+            let deps = IssueDependencies::parse(&issue.body);
+
+            if deps.has_dependencies() {
+                println!("Checking dependencies...");
+                println!();
+
+                let mut blocking = Vec::new();
+
+                for dep_ref in deps.depends_on.iter().chain(deps.blocked_by.iter()) {
+                    if !dep_ref.is_local() {
+                        println!("  ⚠️  {} (cross-repo, skipped)", dep_ref);
+                        continue;
+                    }
+
+                    let status = client.check_dependency_status(dep_ref.number).await?;
+                    let dep_issue = client.get_issue(dep_ref.number).await;
+
+                    let title = dep_issue
+                        .as_ref()
+                        .map(|i| i.title.as_str())
+                        .unwrap_or("(unknown)");
+
+                    match status {
+                        DependencyStatus::Complete => {
+                            println!("  ✅ #{}: {} [complete]", dep_ref.number, title);
+                        }
+                        DependencyStatus::InProgress { pr_number } => {
+                            println!(
+                                "  🔄 #{}: {} [PR #{} open]",
+                                dep_ref.number, title, pr_number
+                            );
+                            blocking.push((dep_ref.number, title.to_string(), Some(pr_number)));
+                        }
+                        DependencyStatus::Pending => {
+                            println!("  ❌ #{}: {} [not started]", dep_ref.number, title);
+                            blocking.push((dep_ref.number, title.to_string(), None));
+                        }
+                    }
+                }
+
+                println!();
+
+                if !blocking.is_empty() {
+                    println!(
+                        "❌ Blocked by {} unmet dependenc{}.",
+                        blocking.len(),
+                        if blocking.len() == 1 { "y" } else { "ies" }
+                    );
+                    println!();
+                    println!("Options:");
+                    for (i, (num, _, pr)) in blocking.iter().enumerate() {
+                        if let Some(pr_num) = pr {
+                            println!(
+                                "  {}. Wait for PR #{} to merge",
+                                i + 1,
+                                pr_num
+                            );
+                        } else {
+                            println!(
+                                "  {}. Run `murmur work {}` to start the blocking issue",
+                                i + 1,
+                                num
+                            );
+                        }
+                    }
+                    println!(
+                        "  {}. Run `murmur work {} --force` to proceed anyway",
+                        blocking.len() + 1,
+                        self.issue
+                    );
+                    println!();
+                    return Ok(());
+                }
+
+                println!("✅ All dependencies satisfied!");
+                println!();
+            }
+        } else {
+            println!("⚠️  Skipping dependency check (--force)");
+            println!();
+        }
+
+        // Check if issue is already closed
+        if issue.state == IssueState::Closed {
+            println!("⚠️  Issue #{} is already closed.", self.issue);
+            if !self.force {
+                println!("Use --force to work on it anyway.");
+                return Ok(());
+            }
+        }
+
+        // Create worktree for the issue
+        println!("Creating worktree for #{}...", self.issue);
+
+        let cwd = std::env::current_dir()?;
+        let git_repo = GitRepo::open(&cwd)?;
+
+        let branching_options = BranchingOptions {
+            base_branch: None,
+            fetch: true,
+            remote: None,
+        };
+
+        let point = git_repo.find_branching_point(&branching_options)?;
+        let branch_name = format!("murmur/issue-{}", self.issue);
+
+        if verbose {
+            println!(
+                "  Branching from {} ({})",
+                point.reference,
+                &point.commit[..8]
+            );
+        }
+
+        let worktree_options = WorktreeOptions {
+            branch_name: branch_name.clone(),
+            force: self.force,
+        };
+
+        let info = git_repo.create_cached_worktree(&point, &worktree_options)?;
+
+        // Save metadata
+        let metadata = WorktreeMetadata::new(
+            &format!("issue-{}", self.issue),
+            &point.commit,
+            &branch_name,
+        );
+        metadata.save(&info.path)?;
+
+        println!("  Created: {}", info.path.display());
+        println!("  Branch:  {}", info.branch);
+        println!();
+
+        if self.no_agent {
+            println!("Worktree ready. Run your agent manually:");
+            println!("  cd {}", info.path.display());
+            return Ok(());
+        }
+
+        // Build prompt from issue
+        let prompt = if let Some(ref custom_prompt) = self.prompt {
+            custom_prompt.clone()
+        } else {
+            build_prompt_from_issue(&issue)
+        };
+
+        println!("Starting agent...");
+        println!();
+
+        // Spawn agent
+        let spawner = AgentSpawner::from_config(config.agent.clone());
+        let mut handle = spawner.spawn(&prompt, &info.path).await?;
+
+        // Stream output
+        let stdout = handle
+            .child_mut()
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout"))?;
+
+        let mut streamer = OutputStreamer::new(stdout);
+        let mut handler = PrintHandler::new(verbose);
+
+        if let Err(e) = streamer.stream(&mut handler).await {
+            eprintln!("Stream error: {}", e);
+        }
+
+        let status = handle.wait().await?;
+
+        println!();
+        if status.success() {
+            println!("✅ Agent completed successfully");
+        } else {
+            println!(
+                "❌ Agent exited with code: {}",
+                status.code().unwrap_or(-1)
+            );
+        }
+
+        println!();
+        println!("Next steps:");
+        println!("  1. Review changes: cd {}", info.path.display());
+        println!("  2. Create PR: gh pr create --title \"Fixes #{}\"", self.issue);
+
+        Ok(())
+    }
+}
+
+fn build_prompt_from_issue(issue: &murmur_github::Issue) -> String {
+    let mut prompt = String::new();
+
+    prompt.push_str(&format!(
+        "Work on GitHub issue #{}: {}\n\n",
+        issue.number, issue.title
+    ));
+
+    // Extract description (before metadata block)
+    let body = issue
+        .body
+        .lines()
+        .take_while(|line| !line.starts_with("<!-- murmur:metadata"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if !body.is_empty() {
+        prompt.push_str("Issue description:\n");
+        prompt.push_str(&body);
+        prompt.push_str("\n\n");
+    }
+
+    prompt.push_str("Please implement this issue. When done, provide a summary of changes made.");
+
+    prompt
+}

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use murmur_core::{Config, GitRepo};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use commands::{IssueArgs, RunArgs, WorktreeArgs};
+use commands::{IssueArgs, RunArgs, WorkArgs, WorktreeArgs};
 
 /// Try to detect the GitHub repo from the current directory
 fn detect_repo() -> Option<String> {
@@ -80,6 +80,10 @@ enum Commands {
     #[command(visible_alias = "i")]
     Issue(IssueArgs),
 
+    /// Work on a GitHub issue
+    #[command(visible_alias = "w")]
+    Work(WorkArgs),
+
     /// Show current configuration
     Config,
 }
@@ -123,6 +127,11 @@ async fn main() -> anyhow::Result<()> {
             // Try to detect repo from current directory
             let repo = detect_repo();
             args.execute(cli.verbose, repo.as_deref()).await?;
+        }
+        Some(Commands::Work(args)) => {
+            // Try to detect repo from current directory
+            let repo = detect_repo();
+            args.execute(cli.verbose, &config, repo.as_deref()).await?;
         }
         Some(Commands::Config) => {
             println!("Murmur Configuration");


### PR DESCRIPTION
## Summary
- Adds `murmur work <issue>` command to start working on GitHub issues
- Checks all dependencies before starting (PRs must be merged)
- Blocks with clear message showing pending dependencies
- Offers suggestions: wait for PR, work on blocker, or use --force
- `--force` flag to skip dependency checks
- `--no-agent` to only create worktree without spawning agent
- `--prompt` for custom agent prompt
- Creates worktree, saves metadata, spawns Claude Code agent
- Builds agent prompt from issue title and description

## Usage
```bash
# Work on an issue (checks dependencies)
murmur work 42

# Force work despite unmet dependencies
murmur work 42 --force

# Just create worktree, don't start agent
murmur work 42 --no-agent

# Custom prompt
murmur work 42 --prompt "Fix the bug described in this issue"
```

## Test plan
- [x] All 56 tests pass
- [ ] Manual testing with real GitHub repo

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)