### PR TITLE
Add secrets.toml for secure GitHub token storage

### DIFF
--- a/docs/github-token.md
+++ b/docs/github-token.md
@@ -33,7 +33,27 @@ The `repo` scope provides broader access than fine-grained tokens but is simpler
 
 ## Setting Up the Token
 
-### Option 1: Environment Variable
+### Option 1: Secrets File (Recommended)
+
+Use murmur's built-in secrets management:
+
+```bash
+# Create the secrets file with secure permissions
+murmur secrets-init
+
+# Edit the file and add your token
+# File location: ~/.config/murmur/secrets.toml
+```
+
+The secrets file format:
+```toml
+[github]
+token = "github_pat_xxxxxxxxxxxx"
+```
+
+The file must have `600` permissions (owner read/write only). Murmur will refuse to read it if it's world-readable.
+
+### Option 2: Environment Variable
 
 ```bash
 export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
@@ -41,13 +61,12 @@ export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) for persistence.
 
-### Option 2: File-based (for scripts)
+The environment variable takes priority over the secrets file.
 
-```bash
-echo "ghp_xxxxxxxxxxxxxxxxxxxx" > ~/.murmur-gh-token
-chmod 600 ~/.murmur-gh-token
-export GITHUB_TOKEN=$(cat ~/.murmur-gh-token)
-```
+### Token Loading Priority
+
+1. `GITHUB_TOKEN` environment variable
+2. `~/.config/murmur/secrets.toml`
 
 ## Token Types
 

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -5,7 +5,7 @@
 mod commands;
 
 use clap::{Parser, Subcommand};
-use murmur_core::{Config, GitRepo};
+use murmur_core::{Config, GitRepo, Secrets};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use commands::{IssueArgs, RunArgs, WorkArgs, WorktreeArgs};
@@ -86,6 +86,10 @@ enum Commands {
 
     /// Show current configuration
     Config,
+
+    /// Initialize secrets file
+    #[command(visible_alias = "init")]
+    SecretsInit,
 }
 
 #[tokio::main]
@@ -147,6 +151,29 @@ async fn main() -> anyhow::Result<()> {
                     println!("  (exists)");
                 } else {
                     println!("  (not found - using defaults)");
+                }
+            }
+            println!();
+            if let Some(path) = Secrets::default_secrets_path() {
+                println!("Secrets file: {}", path.display());
+                if path.exists() {
+                    println!("  (exists)");
+                } else {
+                    println!("  (not found - run 'murmur secrets-init' to create)");
+                }
+            }
+        }
+        Some(Commands::SecretsInit) => {
+            match Secrets::create_template() {
+                Ok(path) => {
+                    println!("Created secrets file: {}", path.display());
+                    println!();
+                    println!("Please edit the file and add your GitHub token.");
+                    println!("Get a token at: https://github.com/settings/tokens");
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
                 }
             }
         }

--- a/murmur-core/src/lib.rs
+++ b/murmur-core/src/lib.rs
@@ -8,12 +8,14 @@ pub mod config;
 pub mod error;
 pub mod git;
 pub mod plan;
+pub mod secrets;
 
 pub use agent::{
     AgentHandle, AgentSpawner, CostInfo, OutputStreamer, PrintHandler, StreamHandler, StreamMessage,
 };
 pub use config::{AgentConfig, Config};
 pub use error::{Error, Result};
+pub use secrets::{GitHubSecrets, Secrets};
 pub use git::{
     cached_repo_path, clone_repo, default_cache_dir, default_repos_cache_dir, fetch_repo,
     is_repo_cached, worktree_path, BranchingOptions, BranchingPoint, CachedWorktree, GitRepo,

--- a/murmur-core/src/secrets.rs
+++ b/murmur-core/src/secrets.rs
@@ -1,0 +1,246 @@
+//! Secrets management for Murmuration
+//!
+//! Secrets are stored separately from configuration to avoid accidental sharing.
+//! The secrets file is located at `~/.config/murmur/secrets.toml` and must have
+//! restrictive permissions (0600 on Unix).
+//!
+//! Loading priority:
+//! 1. Environment variables (GITHUB_TOKEN)
+//! 2. Secrets file (~/.config/murmur/secrets.toml)
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::{Error, Result};
+
+/// Secrets structure
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Secrets {
+    /// GitHub configuration
+    pub github: GitHubSecrets,
+}
+
+/// GitHub-related secrets
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct GitHubSecrets {
+    /// GitHub Personal Access Token
+    pub token: Option<String>,
+}
+
+impl Secrets {
+    /// Load secrets from the default location
+    ///
+    /// Returns default (empty) secrets if file doesn't exist
+    pub fn load() -> Result<Self> {
+        let secrets_path = Self::default_secrets_path();
+
+        if let Some(path) = secrets_path {
+            if path.exists() {
+                return Self::load_from_file(&path);
+            }
+        }
+
+        Ok(Self::default())
+    }
+
+    /// Load secrets from a specific file with permission checking
+    pub fn load_from_file(path: &PathBuf) -> Result<Self> {
+        // Check file permissions on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let metadata = std::fs::metadata(path).map_err(Error::Io)?;
+            let mode = metadata.permissions().mode();
+
+            // Check if file is readable by group or others (mode & 0o077)
+            if mode & 0o077 != 0 {
+                return Err(Error::Config(format!(
+                    "Secrets file {} has insecure permissions {:o}. \
+                     Please run: chmod 600 {}",
+                    path.display(),
+                    mode & 0o777,
+                    path.display()
+                )));
+            }
+
+            debug!(path = %path.display(), mode = format!("{:o}", mode & 0o777), "Secrets file permissions OK");
+        }
+
+        let contents = std::fs::read_to_string(path).map_err(Error::Io)?;
+        let mut secrets: Secrets = toml::from_str(&contents)
+            .map_err(|e| Error::Config(format!("Failed to parse secrets: {}", e)))?;
+
+        // Trim whitespace from token
+        if let Some(ref mut token) = secrets.github.token {
+            *token = token.trim().to_string();
+        }
+
+        Ok(secrets)
+    }
+
+    /// Get the default secrets file path
+    ///
+    /// Returns `~/.config/murmur/secrets.toml` on Unix
+    pub fn default_secrets_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|p| p.join("murmur").join("secrets.toml"))
+    }
+
+    /// Get GitHub token with environment variable override
+    ///
+    /// Priority: GITHUB_TOKEN env var > secrets file
+    pub fn github_token(&self) -> Option<String> {
+        // Check environment variable first
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            let token = token.trim().to_string();
+            if !token.is_empty() {
+                debug!("Using GitHub token from GITHUB_TOKEN environment variable");
+                return Some(token);
+            }
+        }
+
+        // Fall back to secrets file
+        if let Some(ref token) = self.github.token {
+            if !token.is_empty() {
+                debug!("Using GitHub token from secrets file");
+                return Some(token.clone());
+            }
+        }
+
+        None
+    }
+
+    /// Create a template secrets file at the default location
+    ///
+    /// Creates parent directories if needed and sets secure permissions
+    pub fn create_template() -> Result<PathBuf> {
+        let path = Self::default_secrets_path()
+            .ok_or_else(|| Error::Config("Could not determine secrets path".to_string()))?;
+
+        // Create parent directory
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(Error::Io)?;
+        }
+
+        // Don't overwrite existing file
+        if path.exists() {
+            return Err(Error::Config(format!(
+                "Secrets file already exists at {}",
+                path.display()
+            )));
+        }
+
+        let template = r#"# Murmur Secrets
+# This file contains sensitive credentials - do not share or commit to version control
+#
+# IMPORTANT: This file must have restrictive permissions (chmod 600)
+
+[github]
+# GitHub Personal Access Token
+# Create at: https://github.com/settings/tokens
+# Required permissions: repo (or fine-grained: Issues read/write, Pull requests read)
+token = ""
+"#;
+
+        std::fs::write(&path, template).map_err(Error::Io)?;
+
+        // Set restrictive permissions on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(&path, perms).map_err(Error::Io)?;
+        }
+
+        warn!(path = %path.display(), "Created secrets template - please edit and add your tokens");
+
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_default_secrets() {
+        let secrets = Secrets::default();
+        assert!(secrets.github.token.is_none());
+    }
+
+    #[test]
+    fn test_parse_secrets() {
+        let toml = r#"
+[github]
+token = "ghp_xxxxxxxxxxxx"
+"#;
+        let secrets: Secrets = toml::from_str(toml).unwrap();
+        assert_eq!(secrets.github.token, Some("ghp_xxxxxxxxxxxx".to_string()));
+    }
+
+    #[test]
+    fn test_token_with_whitespace() {
+        let toml = r#"
+[github]
+token = "  ghp_xxxxxxxxxxxx  "
+"#;
+        let secrets: Secrets = toml::from_str(toml).unwrap();
+        // toml preserves whitespace, load_from_file trims it
+        assert!(secrets.github.token.as_ref().unwrap().contains("ghp_"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_insecure_permissions_rejected() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[github]\ntoken = \"test\"").unwrap();
+
+        // Set world-readable permissions
+        let perms = std::fs::Permissions::from_mode(0o644);
+        std::fs::set_permissions(file.path(), perms).unwrap();
+
+        let result = Secrets::load_from_file(&file.path().to_path_buf());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("insecure permissions"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_permissions_accepted() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[github]\ntoken = \"ghp_test\"").unwrap();
+
+        // Set owner-only permissions
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(file.path(), perms).unwrap();
+
+        let result = Secrets::load_from_file(&file.path().to_path_buf());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().github.token, Some("ghp_test".to_string()));
+    }
+
+    #[test]
+    fn test_env_var_override() {
+        let secrets = Secrets {
+            github: GitHubSecrets {
+                token: Some("from_file".to_string()),
+            },
+        };
+
+        // Without env var, use file token
+        std::env::remove_var("GITHUB_TOKEN");
+        // Note: can't easily test env var in unit tests due to global state
+        // Just verify the file token works
+        assert_eq!(secrets.github.token, Some("from_file".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `~/.config/murmur/secrets.toml` for storing GitHub token securely
- Enforce `600` permissions - refuse to read world-readable secrets files
- Automatically trim whitespace from tokens (fixes trailing newline issues)
- Add `murmur secrets-init` command to create template with secure permissions
- Token loading priority: `GITHUB_TOKEN` env var > secrets file

## Changes

- `murmur-core/src/secrets.rs`: New module for secrets management
- `murmur-github/src/client.rs`: Use Secrets for token loading
- `murmur-cli/src/main.rs`: Add secrets-init command, show secrets status in config
- `docs/github-token.md`: Update with secrets file instructions

## Test plan

- [x] 76 tests passing
- [x] `murmur config` shows secrets file status
- [x] `murmur secrets-init` creates template with 600 permissions
- [x] Insecure permissions (644) rejected with clear error message
- [x] Token trimming handles trailing newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)