### PR TITLE
Fix: Add --verbose flag required by Claude Code stream-json

### DIFF
--- a/murmur-core/src/agent/spawn.rs
+++ b/murmur-core/src/agent/spawn.rs
@@ -120,6 +120,7 @@ impl AgentSpawner {
 
         let mut cmd = Command::new(claude_cmd);
         cmd.arg("--print")
+            .arg("--verbose")
             .arg("--output-format")
             .arg("stream-json");
 


### PR DESCRIPTION
## Summary

Claude Code now requires `--verbose` when using `--output-format stream-json` with `--print`. Without it, the agent exits immediately with code 1.

## Changes

- Add `--verbose` flag to spawn command arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)