### PR TITLE
Run cargo fmt to format entire codebase

### DIFF
--- a/murmur-cli/src/commands/issue.rs
+++ b/murmur-cli/src/commands/issue.rs
@@ -2,8 +2,8 @@
 
 use clap::{Args, Subcommand, ValueEnum};
 use murmur_github::{
-    DependencyGraph, DependencyStatus, GitHubClient, IssueFilter, IssueDependencies,
-    IssueMetadata, IssueState,
+    DependencyGraph, DependencyStatus, GitHubClient, IssueDependencies, IssueFilter, IssueMetadata,
+    IssueState,
 };
 
 /// Issue management commands
@@ -157,7 +157,10 @@ async fn list_issues(
             String::new()
         };
 
-        println!("{} #{}: {}{}", state_icon, issue.number, issue.title, labels);
+        println!(
+            "{} #{}: {}{}",
+            state_icon, issue.number, issue.title, labels
+        );
     }
 
     Ok(())
@@ -179,7 +182,10 @@ async fn show_issue(number: u64, repo: Option<&str>, verbose: bool) -> anyhow::R
 
     println!();
     println!("#{}: {}", issue.number, issue.title);
-    println!("{}", "=".repeat(issue.title.len() + format!("#{}: ", issue.number).len()));
+    println!(
+        "{}",
+        "=".repeat(issue.title.len() + format!("#{}: ", issue.number).len())
+    );
     println!();
 
     let state_str = match issue.state {
@@ -192,14 +198,8 @@ async fn show_issue(number: u64, repo: Option<&str>, verbose: bool) -> anyhow::R
         println!("Labels: {}", issue.labels.join(", "));
     }
 
-    println!(
-        "Created: {}",
-        issue.created_at.format("%Y-%m-%d %H:%M UTC")
-    );
-    println!(
-        "Updated: {}",
-        issue.updated_at.format("%Y-%m-%d %H:%M UTC")
-    );
+    println!("Created: {}", issue.created_at.format("%Y-%m-%d %H:%M UTC"));
+    println!("Updated: {}", issue.updated_at.format("%Y-%m-%d %H:%M UTC"));
 
     // Parse and show metadata
     if let Some(metadata) = IssueMetadata::parse(&issue.body) {

--- a/murmur-cli/src/commands/run.rs
+++ b/murmur-cli/src/commands/run.rs
@@ -58,7 +58,10 @@ impl RunArgs {
         println!();
 
         if self.dry_run {
-            println!("[Dry run] Would spawn {} agent(s) with the above configuration", self.agents);
+            println!(
+                "[Dry run] Would spawn {} agent(s) with the above configuration",
+                self.agents
+            );
             println!("[Dry run] Claude path: {}", config.agent.claude_path);
             return Ok(());
         }

--- a/murmur-cli/src/commands/work.rs
+++ b/murmur-cli/src/commands/work.rs
@@ -44,8 +44,7 @@ impl WorkArgs {
             )
         })?;
 
-        let client =
-            GitHubClient::from_url(repo_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+        let client = GitHubClient::from_url(repo_str).map_err(|e| anyhow::anyhow!("{}", e))?;
 
         println!(
             "Working on issue #{} in {}/{}",
@@ -115,11 +114,7 @@ impl WorkArgs {
                     println!("Options:");
                     for (i, (num, _, pr)) in blocking.iter().enumerate() {
                         if let Some(pr_num) = pr {
-                            println!(
-                                "  {}. Wait for PR #{} to merge",
-                                i + 1,
-                                pr_num
-                            );
+                            println!("  {}. Wait for PR #{} to merge", i + 1, pr_num);
                         } else {
                             println!(
                                 "  {}. Run `murmur work {}` to start the blocking issue",
@@ -236,16 +231,16 @@ impl WorkArgs {
         if status.success() {
             println!("✅ Agent completed successfully");
         } else {
-            println!(
-                "❌ Agent exited with code: {}",
-                status.code().unwrap_or(-1)
-            );
+            println!("❌ Agent exited with code: {}", status.code().unwrap_or(-1));
         }
 
         println!();
         println!("Next steps:");
         println!("  1. Review changes: cd {}", info.path.display());
-        println!("  2. Create PR: gh pr create --title \"Fixes #{}\"", self.issue);
+        println!(
+            "  2. Create PR: gh pr create --title \"Fixes #{}\"",
+            self.issue
+        );
 
         Ok(())
     }

--- a/murmur-cli/src/commands/worktree.rs
+++ b/murmur-cli/src/commands/worktree.rs
@@ -75,9 +75,7 @@ impl WorktreeArgs {
                 repo,
                 base,
                 force,
-            } => {
-                create_worktree(task, repo.as_deref(), base.as_deref(), *force, verbose).await
-            }
+            } => create_worktree(task, repo.as_deref(), base.as_deref(), *force, verbose).await,
             WorktreeCommand::List { repo } => list_worktrees(repo.as_deref(), verbose).await,
             WorktreeCommand::Clean {
                 all,
@@ -125,7 +123,11 @@ async fn create_worktree(
     let point = git_repo.find_branching_point(&branching_options)?;
 
     if verbose {
-        println!("Branching from: {} ({})", point.reference, &point.commit[..8]);
+        println!(
+            "Branching from: {} ({})",
+            point.reference,
+            &point.commit[..8]
+        );
     }
 
     // Create branch name
@@ -199,14 +201,14 @@ async fn list_worktrees(repo_filter: Option<&str>, verbose: bool) -> anyhow::Res
                     WorktreeStatus::Abandoned => "abandoned",
                     WorktreeStatus::Available => "available",
                 };
-                println!(
-                    "  {} [{}] - task: {}",
-                    path_name, status, meta.task_id
-                );
+                println!("  {} [{}] - task: {}", path_name, status, meta.task_id);
 
                 if verbose {
                     println!("    Branch: {}", meta.branch);
-                    println!("    Base:   {}", &meta.base_commit[..8.min(meta.base_commit.len())]);
+                    println!(
+                        "    Base:   {}",
+                        &meta.base_commit[..8.min(meta.base_commit.len())]
+                    );
                 }
             } else {
                 println!("  {} [unknown]", path_name);
@@ -321,10 +323,7 @@ async fn show_worktree(
                     println!("Task:       {}", meta.task_id);
                     println!("Branch:     {}", meta.branch);
                     println!("Base:       {}", meta.base_commit);
-                    println!(
-                        "Status:     {:?}",
-                        meta.status
-                    );
+                    println!("Status:     {:?}", meta.status);
 
                     // Check if dirty
                     if let Ok(is_dirty) = pool.is_dirty(&wt.path) {

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -143,7 +143,10 @@ async fn main() -> anyhow::Result<()> {
             println!();
             println!("Agent Settings:");
             println!("  claude_path: {}", config.agent.claude_path);
-            println!("  model: {}", config.agent.model.as_deref().unwrap_or("(default)"));
+            println!(
+                "  model: {}",
+                config.agent.model.as_deref().unwrap_or("(default)")
+            );
             println!();
             if let Some(path) = Config::default_config_path() {
                 println!("Config file: {}", path.display());
@@ -163,20 +166,18 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        Some(Commands::SecretsInit) => {
-            match Secrets::create_template() {
-                Ok(path) => {
-                    println!("Created secrets file: {}", path.display());
-                    println!();
-                    println!("Please edit the file and add your GitHub token.");
-                    println!("Get a token at: https://github.com/settings/tokens");
-                }
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    std::process::exit(1);
-                }
+        Some(Commands::SecretsInit) => match Secrets::create_template() {
+            Ok(path) => {
+                println!("Created secrets file: {}", path.display());
+                println!();
+                println!("Please edit the file and add your GitHub token.");
+                println!("Get a token at: https://github.com/settings/tokens");
             }
-        }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        },
         None => {
             println!("Murmuration - Multi-agent orchestration for software development");
             println!();

--- a/murmur-core/src/agent/output.rs
+++ b/murmur-core/src/agent/output.rs
@@ -140,10 +140,7 @@ impl StreamHandler for PrintHandler {
         println!(); // Ensure final newline
         if self.verbose {
             if let Some(c) = cost {
-                eprintln!(
-                    "[tokens: {} in, {} out]",
-                    c.input_tokens, c.output_tokens
-                );
+                eprintln!("[tokens: {} in, {} out]", c.input_tokens, c.output_tokens);
             }
             if let Some(d) = duration_ms {
                 eprintln!("[duration: {}ms]", d);
@@ -202,7 +199,10 @@ impl OutputStreamer {
 
     fn dispatch_message<H: StreamHandler>(handler: &mut H, msg: StreamMessage) {
         match msg {
-            StreamMessage::System { subtype, session_id } => {
+            StreamMessage::System {
+                subtype,
+                session_id,
+            } => {
                 handler.on_system(subtype.as_deref(), session_id.as_deref());
             }
             StreamMessage::Assistant { message } => {
@@ -215,9 +215,7 @@ impl OutputStreamer {
                 handler.on_tool_result(&output, is_error);
             }
             StreamMessage::Result {
-                cost,
-                duration_ms,
-                ..
+                cost, duration_ms, ..
             } => {
                 handler.on_complete(cost.as_ref(), duration_ms);
             }
@@ -259,7 +257,9 @@ mod tests {
         let json = r#"{"type":"result","cost":{"input_tokens":100,"output_tokens":50},"duration_ms":1234}"#;
         let msg: StreamMessage = serde_json::from_str(json).unwrap();
         match msg {
-            StreamMessage::Result { cost, duration_ms, .. } => {
+            StreamMessage::Result {
+                cost, duration_ms, ..
+            } => {
                 let c = cost.unwrap();
                 assert_eq!(c.input_tokens, 100);
                 assert_eq!(c.output_tokens, 50);
@@ -274,7 +274,10 @@ mod tests {
         let json = r#"{"type":"system","subtype":"init","session_id":"abc123"}"#;
         let msg: StreamMessage = serde_json::from_str(json).unwrap();
         match msg {
-            StreamMessage::System { subtype, session_id } => {
+            StreamMessage::System {
+                subtype,
+                session_id,
+            } => {
                 assert_eq!(subtype, Some("init".to_string()));
                 assert_eq!(session_id, Some("abc123".to_string()));
             }

--- a/murmur-core/src/agent/spawn.rs
+++ b/murmur-core/src/agent/spawn.rs
@@ -100,7 +100,11 @@ impl AgentSpawner {
     ///
     /// # Returns
     /// An `AgentHandle` that can be used to monitor and control the process
-    pub async fn spawn(&self, prompt: impl Into<String>, workdir: impl AsRef<Path>) -> Result<AgentHandle> {
+    pub async fn spawn(
+        &self,
+        prompt: impl Into<String>,
+        workdir: impl AsRef<Path>,
+    ) -> Result<AgentHandle> {
         let prompt = prompt.into();
         let workdir_path = workdir.as_ref();
         let workdir_str = workdir_path

--- a/murmur-core/src/config.rs
+++ b/murmur-core/src/config.rs
@@ -59,7 +59,8 @@ impl Config {
     /// Load configuration from a specific file
     pub fn load_from_file(path: &PathBuf) -> Result<Self> {
         let contents = std::fs::read_to_string(path).map_err(Error::Io)?;
-        toml::from_str(&contents).map_err(|e| Error::Config(format!("Failed to parse config: {}", e)))
+        toml::from_str(&contents)
+            .map_err(|e| Error::Config(format!("Failed to parse config: {}", e)))
     }
 
     /// Get the default config file path
@@ -87,7 +88,11 @@ impl Config {
     }
 
     /// Apply CLI flag overrides
-    pub fn with_cli_overrides(mut self, claude_path: Option<String>, model: Option<String>) -> Self {
+    pub fn with_cli_overrides(
+        mut self,
+        claude_path: Option<String>,
+        model: Option<String>,
+    ) -> Self {
         if let Some(path) = claude_path {
             self.agent.claude_path = path;
         }
@@ -102,10 +107,7 @@ impl Config {
     /// Load configuration with all overrides applied
     ///
     /// Priority: CLI > env > config file > defaults
-    pub fn load_with_overrides(
-        claude_path: Option<String>,
-        model: Option<String>,
-    ) -> Result<Self> {
+    pub fn load_with_overrides(claude_path: Option<String>, model: Option<String>) -> Result<Self> {
         Ok(Self::load()?
             .with_env_overrides()
             .with_cli_overrides(claude_path, model))
@@ -141,7 +143,10 @@ model = "claude-sonnet-4-20250514"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.agent.claude_path, "/usr/local/bin/claude");
-        assert_eq!(config.agent.model, Some("claude-sonnet-4-20250514".to_string()));
+        assert_eq!(
+            config.agent.model,
+            Some("claude-sonnet-4-20250514".to_string())
+        );
     }
 
     #[test]

--- a/murmur-core/src/git/branch.rs
+++ b/murmur-core/src/git/branch.rs
@@ -35,9 +35,10 @@ impl GitRepo {
     pub fn fetch(&self, remote_name: Option<&str>) -> Result<()> {
         let remote_name = remote_name.unwrap_or("origin");
 
-        let mut remote = self.inner().find_remote(remote_name).map_err(|e| {
-            Error::Config(format!("Remote '{}' not found: {}", remote_name, e))
-        })?;
+        let mut remote = self
+            .inner()
+            .find_remote(remote_name)
+            .map_err(|e| Error::Config(format!("Remote '{}' not found: {}", remote_name, e)))?;
 
         // Set up callbacks for progress (silent for now)
         let mut callbacks = RemoteCallbacks::new();
@@ -68,7 +69,11 @@ impl GitRepo {
         if options.fetch {
             let remote = options.remote.as_deref().unwrap_or("origin");
             if let Err(e) = self.fetch(Some(remote)) {
-                tracing::warn!("Failed to fetch from {}: {}. Continuing with local state.", remote, e);
+                tracing::warn!(
+                    "Failed to fetch from {}: {}. Continuing with local state.",
+                    remote,
+                    e
+                );
             }
         }
 
@@ -116,11 +121,7 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference
-                .split('/')
-                .last()
-                .unwrap_or(reference)
-                .to_string();
+            let branch_name = reference.split('/').last().unwrap_or(reference).to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),
@@ -148,11 +149,7 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference
-                .split('/')
-                .last()
-                .unwrap_or(reference)
-                .to_string();
+            let branch_name = reference.split('/').last().unwrap_or(reference).to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),
@@ -168,10 +165,13 @@ impl GitRepo {
     pub fn list_local_branches(&self) -> Result<Vec<String>> {
         let mut branches = Vec::new();
 
-        for branch in self.inner().branches(Some(BranchType::Local)).map_err(|e| {
-            Error::Other(format!("Failed to list branches: {}", e))
-        })? {
-            let (branch, _) = branch.map_err(|e| Error::Other(format!("Failed to read branch: {}", e)))?;
+        for branch in self
+            .inner()
+            .branches(Some(BranchType::Local))
+            .map_err(|e| Error::Other(format!("Failed to list branches: {}", e)))?
+        {
+            let (branch, _) =
+                branch.map_err(|e| Error::Other(format!("Failed to read branch: {}", e)))?;
             if let Some(name) = branch.name().ok().flatten() {
                 branches.push(name.to_string());
             }
@@ -185,10 +185,13 @@ impl GitRepo {
         let mut branches = Vec::new();
         let filter_prefix = remote.map(|r| format!("{}/", r));
 
-        for branch in self.inner().branches(Some(BranchType::Remote)).map_err(|e| {
-            Error::Other(format!("Failed to list branches: {}", e))
-        })? {
-            let (branch, _) = branch.map_err(|e| Error::Other(format!("Failed to read branch: {}", e)))?;
+        for branch in self
+            .inner()
+            .branches(Some(BranchType::Remote))
+            .map_err(|e| Error::Other(format!("Failed to list branches: {}", e)))?
+        {
+            let (branch, _) =
+                branch.map_err(|e| Error::Other(format!("Failed to read branch: {}", e)))?;
             if let Some(name) = branch.name().ok().flatten() {
                 // Filter by remote if specified
                 if let Some(ref prefix) = filter_prefix {

--- a/murmur-core/src/git/clone.rs
+++ b/murmur-core/src/git/clone.rs
@@ -129,9 +129,8 @@ pub fn clone_repo(repo_url: &RepoUrl, cache_dir: Option<&Path>) -> Result<PathBu
 
     // Create parent directories
     if let Some(parent) = target_dir.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            Error::Other(format!("Failed to create repos cache directory: {}", e))
-        })?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| Error::Other(format!("Failed to create repos cache directory: {}", e)))?;
     }
 
     // Clone the repository

--- a/murmur-core/src/git/pool.rs
+++ b/murmur-core/src/git/pool.rs
@@ -60,7 +60,11 @@ pub struct WorktreeMetadata {
 
 impl WorktreeMetadata {
     /// Create new metadata for a fresh worktree
-    pub fn new(task_id: impl Into<String>, base_commit: impl Into<String>, branch: impl Into<String>) -> Self {
+    pub fn new(
+        task_id: impl Into<String>,
+        base_commit: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> Self {
         let now = SystemTime::now();
         Self {
             task_id: task_id.into(),
@@ -80,25 +84,21 @@ impl WorktreeMetadata {
     /// Load metadata from a worktree directory
     pub fn load(worktree_path: &Path) -> Result<Self> {
         let meta_path = worktree_path.join(METADATA_FILE);
-        let contents = fs::read_to_string(&meta_path).map_err(|e| {
-            Error::Config(format!("Failed to read worktree metadata: {}", e))
-        })?;
+        let contents = fs::read_to_string(&meta_path)
+            .map_err(|e| Error::Config(format!("Failed to read worktree metadata: {}", e)))?;
 
-        toml::from_str(&contents).map_err(|e| {
-            Error::Config(format!("Failed to parse worktree metadata: {}", e))
-        })
+        toml::from_str(&contents)
+            .map_err(|e| Error::Config(format!("Failed to parse worktree metadata: {}", e)))
     }
 
     /// Save metadata to a worktree directory
     pub fn save(&self, worktree_path: &Path) -> Result<()> {
         let meta_path = worktree_path.join(METADATA_FILE);
-        let contents = toml::to_string_pretty(self).map_err(|e| {
-            Error::Other(format!("Failed to serialize worktree metadata: {}", e))
-        })?;
+        let contents = toml::to_string_pretty(self)
+            .map_err(|e| Error::Other(format!("Failed to serialize worktree metadata: {}", e)))?;
 
-        fs::write(&meta_path, contents).map_err(|e| {
-            Error::Other(format!("Failed to write worktree metadata: {}", e))
-        })
+        fs::write(&meta_path, contents)
+            .map_err(|e| Error::Other(format!("Failed to write worktree metadata: {}", e)))
     }
 }
 
@@ -119,7 +119,7 @@ impl Default for PoolConfig {
     fn default() -> Self {
         Self {
             max_per_repo: 10,
-            max_total_size: 0,      // Unlimited by default
+            max_total_size: 0,           // Unlimited by default
             max_age_secs: 7 * 24 * 3600, // 7 days
         }
     }
@@ -180,12 +180,11 @@ impl WorktreePool {
 
         let mut worktrees = Vec::new();
 
-        for entry in fs::read_dir(&repo_dir).map_err(|e| {
-            Error::Other(format!("Failed to read cache directory: {}", e))
-        })? {
-            let entry = entry.map_err(|e| {
-                Error::Other(format!("Failed to read directory entry: {}", e))
-            })?;
+        for entry in fs::read_dir(&repo_dir)
+            .map_err(|e| Error::Other(format!("Failed to read cache directory: {}", e)))?
+        {
+            let entry = entry
+                .map_err(|e| Error::Other(format!("Failed to read directory entry: {}", e)))?;
 
             let path = entry.path();
             if path.is_dir() {
@@ -290,13 +289,27 @@ impl WorktreePool {
         let remaining = self.list_worktrees(repo_name)?;
         if remaining.len() > self.config.max_per_repo {
             // Sort by last_used (oldest first)
-            let mut sorted: Vec<_> = remaining.into_iter()
-                .filter(|wt| wt.metadata.as_ref().map(|m| m.status != WorktreeStatus::Active).unwrap_or(true))
+            let mut sorted: Vec<_> = remaining
+                .into_iter()
+                .filter(|wt| {
+                    wt.metadata
+                        .as_ref()
+                        .map(|m| m.status != WorktreeStatus::Active)
+                        .unwrap_or(true)
+                })
                 .collect();
 
             sorted.sort_by(|a, b| {
-                let a_time = a.metadata.as_ref().map(|m| m.last_used).unwrap_or(SystemTime::UNIX_EPOCH);
-                let b_time = b.metadata.as_ref().map(|m| m.last_used).unwrap_or(SystemTime::UNIX_EPOCH);
+                let a_time = a
+                    .metadata
+                    .as_ref()
+                    .map(|m| m.last_used)
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                let b_time = b
+                    .metadata
+                    .as_ref()
+                    .map(|m| m.last_used)
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
                 a_time.cmp(&b_time)
             });
 

--- a/murmur-core/src/git/repo.rs
+++ b/murmur-core/src/git/repo.rs
@@ -80,7 +80,10 @@ impl GitRepo {
         }
 
         // Fall back to first available remote
-        let remotes = self.repo.remotes().map_err(|e| Error::Other(format!("Failed to list remotes: {}", e)))?;
+        let remotes = self
+            .repo
+            .remotes()
+            .map_err(|e| Error::Other(format!("Failed to list remotes: {}", e)))?;
 
         for remote_name in remotes.iter().flatten() {
             if let Ok(remote) = self.repo.find_remote(remote_name) {
@@ -100,7 +103,10 @@ impl GitRepo {
 
     /// List all remotes
     pub fn list_remotes(&self) -> Result<Vec<RemoteInfo>> {
-        let remotes = self.repo.remotes().map_err(|e| Error::Other(format!("Failed to list remotes: {}", e)))?;
+        let remotes = self
+            .repo
+            .remotes()
+            .map_err(|e| Error::Other(format!("Failed to list remotes: {}", e)))?;
 
         let mut result = Vec::new();
         for remote_name in remotes.iter().flatten() {
@@ -141,7 +147,11 @@ impl GitRepo {
         }
 
         // Check if origin/master exists
-        if self.repo.find_reference("refs/remotes/origin/master").is_ok() {
+        if self
+            .repo
+            .find_reference("refs/remotes/origin/master")
+            .is_ok()
+        {
             return Ok("master".to_string());
         }
 

--- a/murmur-core/src/git/worktree.rs
+++ b/murmur-core/src/git/worktree.rs
@@ -74,9 +74,8 @@ impl GitRepo {
 
         // Ensure parent directory exists
         if let Some(parent) = worktree_dir.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                Error::Other(format!("Failed to create worktree directory: {}", e))
-            })?;
+            std::fs::create_dir_all(parent)
+                .map_err(|e| Error::Other(format!("Failed to create worktree directory: {}", e)))?;
         }
 
         // Use git worktree add command
@@ -90,9 +89,9 @@ impl GitRepo {
             .arg(&branching_point.commit)
             .current_dir(self.root());
 
-        let output = cmd.output().map_err(|e| {
-            Error::Other(format!("Failed to run git worktree: {}", e))
-        })?;
+        let output = cmd
+            .output()
+            .map_err(|e| Error::Other(format!("Failed to run git worktree: {}", e)))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -105,10 +104,7 @@ impl GitRepo {
                 )));
             }
 
-            return Err(Error::Other(format!(
-                "git worktree add failed: {}",
-                stderr
-            )));
+            return Err(Error::Other(format!("git worktree add failed: {}", stderr)));
         }
 
         Ok(WorktreeInfo {

--- a/murmur-core/src/lib.rs
+++ b/murmur-core/src/lib.rs
@@ -15,7 +15,6 @@ pub use agent::{
 };
 pub use config::{AgentConfig, Config};
 pub use error::{Error, Result};
-pub use secrets::{GitHubSecrets, Secrets};
 pub use git::{
     cached_repo_path, clone_repo, default_cache_dir, default_repos_cache_dir, fetch_repo,
     is_repo_cached, worktree_path, BranchingOptions, BranchingPoint, CachedWorktree, GitRepo,
@@ -23,3 +22,4 @@ pub use git::{
     WorktreeStatus,
 };
 pub use plan::{parse_plan, Phase, Plan, PlannedPR};
+pub use secrets::{GitHubSecrets, Secrets};

--- a/murmur-core/src/plan/parser.rs
+++ b/murmur-core/src/plan/parser.rs
@@ -202,7 +202,10 @@ fn parse_table_row(line: &str, prev_pr_id: &Option<String>) -> Option<PlannedPR>
     let depends_on = if let Some(prev) = prev_pr_id {
         // Sub-PRs depend on their parent, not previous
         if is_sub_pr {
-            parent_pr.as_ref().map(|p| vec![p.clone()]).unwrap_or_default()
+            parent_pr
+                .as_ref()
+                .map(|p| vec![p.clone()])
+                .unwrap_or_default()
         } else {
             vec![prev.clone()]
         }
@@ -294,7 +297,10 @@ Test description.
     #[test]
     fn test_parse_checkpoint() {
         let plan = parse_plan(SAMPLE_PLAN).unwrap();
-        assert_eq!(plan.phases[0].checkpoint, Some("First checkpoint.".to_string()));
+        assert_eq!(
+            plan.phases[0].checkpoint,
+            Some("First checkpoint.".to_string())
+        );
     }
 
     #[test]

--- a/murmur-core/src/secrets.rs
+++ b/murmur-core/src/secrets.rs
@@ -209,7 +209,10 @@ token = "  ghp_xxxxxxxxxxxx  "
 
         let result = Secrets::load_from_file(&file.path().to_path_buf());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("insecure permissions"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("insecure permissions"));
     }
 
     #[cfg(unix)]

--- a/murmur-github/src/client.rs
+++ b/murmur-github/src/client.rs
@@ -132,7 +132,10 @@ fn parse_github_url(url: &str) -> Result<(String, String)> {
         // Simple owner/repo format
         let parts: Vec<&str> = url.split('/').collect();
         if parts.len() == 2 {
-            return Ok((parts[0].to_string(), parts[1].trim_end_matches(".git").to_string()));
+            return Ok((
+                parts[0].to_string(),
+                parts[1].trim_end_matches(".git").to_string(),
+            ));
         }
         return Err(Error::Parse(format!(
             "Invalid repository format: {}. Expected owner/repo",

--- a/murmur-github/src/create.rs
+++ b/murmur-github/src/create.rs
@@ -34,11 +34,7 @@ pub struct ImportOptions {
 
 impl GitHubClient {
     /// Import a plan to GitHub as issues
-    pub async fn import_plan(
-        &self,
-        plan: &Plan,
-        options: &ImportOptions,
-    ) -> Result<ImportResult> {
+    pub async fn import_plan(&self, plan: &Plan, options: &ImportOptions) -> Result<ImportResult> {
         let mut result = ImportResult::default();
 
         // Get existing issues to check for duplicates
@@ -82,7 +78,9 @@ impl GitHubClient {
                 }
                 Err(e) => {
                     warn!(title = %epic_title, error = %e, "Failed to create epic");
-                    result.errors.push(format!("Failed to create epic '{}': {}", epic_title, e));
+                    result
+                        .errors
+                        .push(format!("Failed to create epic '{}': {}", epic_title, e));
                 }
             }
         }

--- a/murmur-github/src/dependencies.rs
+++ b/murmur-github/src/dependencies.rs
@@ -305,7 +305,10 @@ impl DependencyGraph {
 
 /// Parse "Depends on #X" and "Depends on owner/repo#X" patterns
 fn parse_depends_pattern(body: &str) -> Vec<IssueRef> {
-    parse_issue_refs(body, &["Depends on", "depends on", "Depend on", "depend on"])
+    parse_issue_refs(
+        body,
+        &["Depends on", "depends on", "Depend on", "depend on"],
+    )
 }
 
 /// Parse "Blocked by #X" patterns
@@ -364,7 +367,10 @@ fn parse_single_issue_ref(s: &str) -> Option<IssueRef> {
         let after_hash = &s[hash_pos + 1..];
 
         // Parse the number
-        let num_str: String = after_hash.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let num_str: String = after_hash
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
         let number = num_str.parse::<u64>().ok()?;
 
         if before_hash.is_empty() {

--- a/murmur-github/src/issues.rs
+++ b/murmur-github/src/issues.rs
@@ -82,9 +82,7 @@ impl GitHubClient {
             .get(number)
             .await
             .map_err(|e| match &e {
-                octocrab::Error::GitHub { source, .. }
-                    if source.message.contains("Not Found") =>
-                {
+                octocrab::Error::GitHub { source, .. } if source.message.contains("Not Found") => {
                     Error::IssueNotFound(number)
                 }
                 _ => Error::Api(e),

--- a/murmur-github/src/metadata.rs
+++ b/murmur-github/src/metadata.rs
@@ -127,7 +127,12 @@ pub fn parse_depends_on_links(body: &str) -> Vec<u64> {
     let mut deps = Vec::new();
 
     // Pattern: "Depends on #123" or "depends on #123"
-    let patterns = ["Depends on #", "depends on #", "Blocked by #", "blocked by #"];
+    let patterns = [
+        "Depends on #",
+        "depends on #",
+        "Blocked by #",
+        "blocked by #",
+    ];
 
     for pattern in patterns {
         for part in body.split(pattern).skip(1) {

--- a/murmur-github/src/pr.rs
+++ b/murmur-github/src/pr.rs
@@ -109,9 +109,7 @@ impl GitHubClient {
             .get(number)
             .await
             .map_err(|e| match &e {
-                octocrab::Error::GitHub { source, .. }
-                    if source.message.contains("Not Found") =>
-                {
+                octocrab::Error::GitHub { source, .. } if source.message.contains("Not Found") => {
                     Error::PrNotFound(number)
                 }
                 _ => Error::Api(e),
@@ -170,11 +168,7 @@ impl GitHubClient {
             })
             .collect();
 
-        info!(
-            issue_number,
-            count = matching.len(),
-            "Found PRs for issue"
-        );
+        info!(issue_number, count = matching.len(), "Found PRs for issue");
 
         Ok(matching)
     }
@@ -211,7 +205,9 @@ impl GitHubClient {
         // Check if any PR is open (in progress)
         for pr in &prs {
             if pr.state == PrState::Open {
-                return Ok(DependencyStatus::InProgress { pr_number: pr.number });
+                return Ok(DependencyStatus::InProgress {
+                    pr_number: pr.number,
+                });
             }
         }
 


### PR DESCRIPTION
## Summary

- Runs `cargo fmt --all` to format the entire codebase consistently
- No functional changes, formatting only

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)