### PR TITLE
Fix clippy warnings across the codebase (#83)

### DIFF
--- a/.murmur-worktree.toml
+++ b/.murmur-worktree.toml
@@ -1,0 +1,6 @@
+task_id = "issue-83"
+created_at = "2025-12-04T20:04:06.035663065Z"
+last_used = "2025-12-04T20:04:06.035663065Z"
+base_commit = "9c1ba9d027569f3d3eba5761ccc2526e56ecc824"
+status = "active"
+branch = "murmur/issue-83"

--- a/murmur-cli/src/commands/work.rs
+++ b/murmur-cli/src/commands/work.rs
@@ -181,7 +181,7 @@ impl WorkArgs {
 
         // Save metadata
         let metadata = WorktreeMetadata::new(
-            &format!("issue-{}", self.issue),
+            format!("issue-{}", self.issue),
             &point.commit,
             &branch_name,
         );

--- a/murmur-core/src/agent/spawn.rs
+++ b/murmur-core/src/agent/spawn.rs
@@ -55,18 +55,10 @@ impl AgentHandle {
 }
 
 /// Spawner for Claude Code agent processes
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AgentSpawner {
     /// Agent configuration
     config: AgentConfig,
-}
-
-impl Default for AgentSpawner {
-    fn default() -> Self {
-        Self {
-            config: AgentConfig::default(),
-        }
-    }
 }
 
 impl AgentSpawner {

--- a/murmur-core/src/git/branch.rs
+++ b/murmur-core/src/git/branch.rs
@@ -121,7 +121,7 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference.split('/').last().unwrap_or(reference).to_string();
+            let branch_name = reference.split('/').next_back().unwrap_or(reference).to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),
@@ -149,7 +149,7 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference.split('/').last().unwrap_or(reference).to_string();
+            let branch_name = reference.split('/').next_back().unwrap_or(reference).to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),
@@ -222,8 +222,7 @@ mod tests {
 
             // Should find some branching point in a valid repo
             let result = repo.find_branching_point(&options);
-            if result.is_ok() {
-                let point = result.unwrap();
+            if let Ok(point) = result {
                 assert!(!point.commit.is_empty());
                 assert!(!point.branch_name.is_empty());
             }

--- a/murmur-core/src/git/pool.rs
+++ b/murmur-core/src/git/pool.rs
@@ -250,19 +250,10 @@ impl WorktreePool {
         for wt in worktrees {
             let should_remove = if let Some(ref meta) = wt.metadata {
                 // Check if too old
-                if self.config.max_age_secs > 0 {
-                    if let Ok(age) = now.duration_since(meta.last_used) {
-                        if age > max_age && meta.status != WorktreeStatus::Active {
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
+                self.config.max_age_secs > 0
+                    && now
+                        .duration_since(meta.last_used)
+                        .is_ok_and(|age| age > max_age && meta.status != WorktreeStatus::Active)
             } else {
                 // No metadata, consider for removal if old
                 if let Ok(modified) = fs::metadata(&wt.path).and_then(|m| m.modified()) {

--- a/murmur-core/src/git/worktree.rs
+++ b/murmur-core/src/git/worktree.rs
@@ -40,10 +40,7 @@ pub fn default_cache_dir() -> Result<PathBuf> {
 /// Generate a worktree path from repo info and branch name
 pub fn worktree_path(cache_dir: &Path, repo_name: &str, branch_name: &str) -> PathBuf {
     // Sanitize branch name for filesystem
-    let safe_branch = branch_name
-        .replace('/', "-")
-        .replace('\\', "-")
-        .replace(':', "-");
+    let safe_branch = branch_name.replace(['/', '\\', ':'], "-");
 
     cache_dir.join(repo_name).join(safe_branch)
 }

--- a/murmur-core/src/plan/parser.rs
+++ b/murmur-core/src/plan/parser.rs
@@ -74,14 +74,13 @@ pub fn parse_plan(content: &str) -> Result<Plan> {
         }
 
         // Detect phase headers: ### Phase N: Name
-        if line.starts_with("### Phase ") {
+        if let Some(rest) = line.strip_prefix("### Phase ") {
             // Save previous phase
             if let Some(phase) = current_phase.take() {
                 plan.phases.push(phase);
             }
 
             // Parse phase header
-            let rest = &line[10..]; // Skip "### Phase "
             if let Some((id, name)) = parse_phase_header(rest) {
                 current_phase = Some(Phase {
                     id,
@@ -106,8 +105,8 @@ pub fn parse_plan(content: &str) -> Result<Plan> {
             }
 
             // Checkpoint line: **Checkpoint:** ...
-            if line.starts_with("**Checkpoint:**") {
-                phase.checkpoint = Some(line[15..].trim().to_string());
+            if let Some(rest) = line.strip_prefix("**Checkpoint:**") {
+                phase.checkpoint = Some(rest.trim().to_string());
                 continue;
             }
 

--- a/murmur-github/src/client.rs
+++ b/murmur-github/src/client.rs
@@ -1,5 +1,9 @@
 //! GitHub API client using octocrab
 
+// Allow large error types from octocrab - they're external and would require
+// boxing the error everywhere, which adds complexity without significant benefit
+#![allow(clippy::result_large_err)]
+
 use crate::{Error, Result};
 use murmur_core::Secrets;
 use octocrab::Octocrab;

--- a/murmur-github/src/dependencies.rs
+++ b/murmur-github/src/dependencies.rs
@@ -259,10 +259,10 @@ impl DependencyGraph {
             .collect();
 
         for &node in &all_nodes {
-            if !visited.contains(&node) {
-                if !self.topo_visit(node, &mut visited, &mut temp_visited, &mut order) {
-                    return None; // Cycle detected
-                }
+            if !visited.contains(&node)
+                && !self.topo_visit(node, &mut visited, &mut temp_visited, &mut order)
+            {
+                return None; // Cycle detected
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix all clippy warnings across murmur-core, murmur-github, and murmur-cli
- Changes include using `next_back()` instead of `last()`, `strip_prefix()` instead of manual slicing, deriving Default, and simplifying boolean expressions
- Added `#![allow(clippy::result_large_err)]` to client.rs to suppress warnings about large error types from octocrab (external dependency)

Fixes #83

## Test plan
- [x] Run `cargo clippy --all-targets` to verify no warnings
- [x] Verify code compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)