### PR TITLE
ci: add GitHub Actions workflow and pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features
+
+  test:
+    name: Test (${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable, beta]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --all-features
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Pre-commit hooks for code quality
+# Install: pip install pre-commit && pre-commit install
+
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,11 @@ chrono = { version = "0.4", features = ["serde"] }
 # Internal crates
 murmur-core = { path = "murmur-core" }
 murmur-github = { path = "murmur-github" }
+
+[workspace.lints.rust]
+unsafe_code = "warn"
+
+[workspace.lints.clippy]
+all = "warn"
+# Pedantic lints disabled for now - enable gradually
+# pedantic = { level = "warn", priority = -1 }

--- a/murmur-cli/Cargo.toml
+++ b/murmur-cli/Cargo.toml
@@ -19,3 +19,6 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 chrono.workspace = true
+
+[lints]
+workspace = true

--- a/murmur-cli/src/commands/work.rs
+++ b/murmur-cli/src/commands/work.rs
@@ -180,11 +180,8 @@ impl WorkArgs {
         let info = git_repo.create_cached_worktree(&point, &worktree_options)?;
 
         // Save metadata
-        let metadata = WorktreeMetadata::new(
-            format!("issue-{}", self.issue),
-            &point.commit,
-            &branch_name,
-        );
+        let metadata =
+            WorktreeMetadata::new(format!("issue-{}", self.issue), &point.commit, &branch_name);
         metadata.save(&info.path)?;
 
         println!("  Created: {}", info.path.display());

--- a/murmur-core/Cargo.toml
+++ b/murmur-core/Cargo.toml
@@ -20,3 +20,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3.15"
+
+[lints]
+workspace = true

--- a/murmur-core/src/agent/output.rs
+++ b/murmur-core/src/agent/output.rs
@@ -55,9 +55,7 @@ pub enum StreamMessage {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentBlock {
     /// Text content
-    Text {
-        text: String,
-    },
+    Text { text: String },
     /// Tool use content
     ToolUse {
         id: String,
@@ -261,7 +259,8 @@ mod tests {
     #[test]
     fn test_parse_assistant_message_new_format() {
         // New Claude Code format with content as array
-        let json = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
+        let json =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
         let msg: StreamMessage = serde_json::from_str(json).unwrap();
         match msg {
             StreamMessage::Assistant { message } => {

--- a/murmur-core/src/git/branch.rs
+++ b/murmur-core/src/git/branch.rs
@@ -121,7 +121,11 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference.split('/').next_back().unwrap_or(reference).to_string();
+            let branch_name = reference
+                .split('/')
+                .next_back()
+                .unwrap_or(reference)
+                .to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),
@@ -149,7 +153,11 @@ impl GitRepo {
                 .peel_to_commit()
                 .map_err(|e| Error::Other(format!("Failed to resolve {}: {}", reference, e)))?;
 
-            let branch_name = reference.split('/').next_back().unwrap_or(reference).to_string();
+            let branch_name = reference
+                .split('/')
+                .next_back()
+                .unwrap_or(reference)
+                .to_string();
 
             return Ok(BranchingPoint {
                 reference: reference.to_string(),

--- a/murmur-core/src/git/pool.rs
+++ b/murmur-core/src/git/pool.rs
@@ -15,7 +15,7 @@ use crate::{Error, Result};
 const METADATA_FILE: &str = ".murmur-worktree.toml";
 
 /// Status of a cached worktree
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorktreeStatus {
     /// Actively being used by an agent
@@ -25,13 +25,8 @@ pub enum WorktreeStatus {
     /// Work was abandoned or failed
     Abandoned,
     /// Ready to be reused
+    #[default]
     Available,
-}
-
-impl Default for WorktreeStatus {
-    fn default() -> Self {
-        Self::Available
-    }
 }
 
 /// Metadata stored with each cached worktree

--- a/murmur-github/Cargo.toml
+++ b/murmur-github/Cargo.toml
@@ -16,3 +16,6 @@ thiserror.workspace = true
 tracing.workspace = true
 url.workspace = true
 chrono.workspace = true
+
+[lints]
+workspace = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+# Rust formatting configuration
+# https://rust-lang.github.io/rustfmt/
+
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"


### PR DESCRIPTION
## Summary
- Add CI workflow with fmt, clippy, test (stable+beta), and build jobs
- Add pre-commit hooks for cargo fmt, clippy, and conventional commits
- Add rustfmt.toml with max_width=100 and apply formatting
- Configure workspace-level clippy lints inherited by all crates

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test --all-features` passes (78 tests)
- [ ] CI workflow runs successfully on push

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)