### PR TITLE
feat(cli): add murmur agent start --type command

### DIFF
--- a/murmur-cli/src/commands/agent.rs
+++ b/murmur-cli/src/commands/agent.rs
@@ -1,0 +1,138 @@
+//! Agent command - Start a typed agent with specialized behavior
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use murmur_core::{AgentFactory, AgentType, Config, OutputStreamer, PrintHandler};
+
+/// Arguments for the agent command
+#[derive(Args, Debug)]
+pub struct AgentArgs {
+    #[command(subcommand)]
+    pub command: AgentCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentCommands {
+    /// Start an agent with a specific type
+    Start(StartArgs),
+}
+
+/// Arguments for the start subcommand
+#[derive(Args, Debug)]
+pub struct StartArgs {
+    /// The type of agent to start (implement, test, review, coordinator)
+    #[arg(long = "type", short = 't', value_parser = parse_agent_type)]
+    pub agent_type: AgentType,
+
+    /// The task prompt describing what to accomplish
+    #[arg(required = true)]
+    pub prompt: String,
+
+    /// Working directory for the task (defaults to current directory)
+    #[arg(short = 'd', long, default_value = ".")]
+    pub workdir: PathBuf,
+
+    /// Dry run - show what would be executed without running
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Parse agent type from string
+fn parse_agent_type(s: &str) -> Result<AgentType, String> {
+    s.parse::<AgentType>()
+}
+
+impl AgentArgs {
+    /// Execute the agent command
+    pub async fn execute(&self, verbose: bool, config: &Config) -> anyhow::Result<()> {
+        match &self.command {
+            AgentCommands::Start(args) => args.execute(verbose, config).await,
+        }
+    }
+}
+
+impl StartArgs {
+    /// Execute the start command
+    pub async fn execute(&self, verbose: bool, config: &Config) -> anyhow::Result<()> {
+        // Resolve to absolute path
+        let workdir = if self.workdir.is_absolute() {
+            self.workdir.clone()
+        } else {
+            std::env::current_dir()?.join(&self.workdir)
+        };
+
+        if verbose {
+            tracing::info!(
+                agent_type = %self.agent_type,
+                prompt = %self.prompt,
+                workdir = %workdir.display(),
+                claude_path = %config.agent.claude_path,
+                model = ?config.agent.model,
+                "Starting typed agent"
+            );
+        }
+
+        println!("Murmuration Typed Agent");
+        println!("========================");
+        println!();
+        println!(
+            "Agent type: {} ({})",
+            self.agent_type,
+            self.agent_type.description()
+        );
+        println!("Prompt: {}", self.prompt);
+        println!("Working directory: {}", workdir.display());
+        if let Some(ref model) = config.agent.model {
+            println!("Model: {}", model);
+        }
+        println!();
+
+        if self.dry_run {
+            println!(
+                "[Dry run] Would spawn {} agent with the above configuration",
+                self.agent_type
+            );
+            println!("[Dry run] Claude path: {}", config.agent.claude_path);
+            return Ok(());
+        }
+
+        // Create factory with config
+        let factory = AgentFactory::with_config(config.agent.clone());
+
+        // Create the typed agent
+        let typed_agent = factory.create(self.agent_type);
+
+        println!("Spawning {} agent...", self.agent_type);
+
+        // Spawn the agent with the task
+        let mut handle = typed_agent.spawn_with_task(&self.prompt, &workdir).await?;
+
+        // Get stdout for streaming
+        let stdout = handle
+            .child_mut()
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
+
+        println!("Agent started, streaming output...");
+        println!();
+
+        // Stream the output
+        let mut streamer = OutputStreamer::new(stdout);
+        let mut handler = PrintHandler::new(verbose);
+        streamer.stream(&mut handler).await?;
+
+        // Wait for the process to complete
+        let status = handle.wait().await?;
+
+        println!();
+        if status.success() {
+            println!("Agent completed successfully");
+        } else {
+            println!("Agent exited with status: {}", status);
+        }
+
+        Ok(())
+    }
+}

--- a/murmur-cli/src/commands/mod.rs
+++ b/murmur-cli/src/commands/mod.rs
@@ -1,11 +1,13 @@
 //! CLI command implementations
 
+pub mod agent;
 pub mod issue;
 pub mod run;
 pub mod status;
 pub mod work;
 pub mod worktree;
 
+pub use agent::AgentArgs;
 pub use issue::IssueArgs;
 pub use run::RunArgs;
 pub use status::StatusArgs;

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use murmur_core::{Config, GitRepo, Secrets};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use commands::{IssueArgs, RunArgs, StatusArgs, WorkArgs, WorktreeArgs};
+use commands::{AgentArgs, IssueArgs, RunArgs, StatusArgs, WorkArgs, WorktreeArgs};
 
 /// Try to detect the GitHub repo from the current directory
 fn detect_repo() -> Option<String> {
@@ -76,6 +76,10 @@ enum Commands {
     #[command(visible_alias = "r")]
     Run(RunArgs),
 
+    /// Start a typed agent with specialized behavior
+    #[command(visible_alias = "a")]
+    Agent(AgentArgs),
+
     /// Manage git worktrees
     #[command(visible_alias = "wt")]
     Worktree(WorktreeArgs),
@@ -130,6 +134,9 @@ async fn main() -> anyhow::Result<()> {
             println!("murmur {}", env!("CARGO_PKG_VERSION"));
         }
         Some(Commands::Run(args)) => {
+            args.execute(cli.verbose, &config).await?;
+        }
+        Some(Commands::Agent(args)) => {
             args.execute(cli.verbose, &config).await?;
         }
         Some(Commands::Worktree(args)) => {


### PR DESCRIPTION
## Summary

Adds `murmur agent start` command to spawn typed agents with specialized prompts and behaviors.

### Features

- `--type/-t`: specify agent type (implement, test, review, coordinator)
- `--dry-run`: preview configuration without spawning
- `--workdir/-d`: specify working directory

### Usage

```bash
# Spawn an implement agent
murmur agent start --type implement "Add feature X"

# Short form with test agent
murmur a start -t test "Write tests for auth module"

# Dry run to preview
murmur a start -t review "Review the changes" --dry-run
```

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] cargo clippy passes
- [x] cargo fmt passes

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)