### PR TITLE
feat(cli): add --backend flag for backend selection

### DIFF
--- a/.murmur-worktree.toml
+++ b/.murmur-worktree.toml
@@ -1,6 +1,0 @@
-task_id = "issue-129"
-created_at = "2025-12-05T23:51:32.121568933Z"
-last_used = "2025-12-05T23:51:32.121568933Z"
-base_commit = "1f126dc184f50fa98ebe66a16b048e4632a2b64f"
-status = "active"
-branch = "murmur/issue-129"

--- a/murmur-cli/src/main.rs
+++ b/murmur-cli/src/main.rs
@@ -59,6 +59,10 @@ struct Cli {
     #[arg(long, global = true, env = "MURMUR_MODEL")]
     model: Option<String>,
 
+    /// Backend to use: claude or cursor (overrides config and env)
+    #[arg(long, global = true, env = "MURMUR_BACKEND")]
+    backend: Option<String>,
+
     /// Disable emoji output (use ASCII alternatives)
     #[arg(long, global = true)]
     no_emoji: bool,
@@ -119,7 +123,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Load configuration with overrides
-    let config = Config::load_with_overrides(cli.claude_path.clone(), cli.model.clone())?;
+    let config = Config::load_with_overrides(
+        cli.claude_path.clone(),
+        cli.model.clone(),
+        cli.backend.clone(),
+    )?;
 
     if cli.verbose {
         tracing::info!(
@@ -162,6 +170,7 @@ async fn main() -> anyhow::Result<()> {
             println!("====================");
             println!();
             println!("Agent Settings:");
+            println!("  backend: {}", config.agent.backend);
             println!("  claude_path: {}", config.agent.claude_path);
             println!(
                 "  model: {}",


### PR DESCRIPTION
## Summary

Adds global `--backend` flag to CLI for runtime backend selection, completing the override chain for Phase 4.5 (#124).

### Override Chain

**Priority**: CLI flags → env vars → config file → defaults

### Usage

```bash
# Use cursor backend with a specific model
murmur work 123 --backend cursor --model gpt-4

# Via environment variable
MURMUR_BACKEND=cursor murmur work 123
```

### Changes

- **CLI**: Add `--backend` global flag to Cli struct
- **Env**: Support `MURMUR_BACKEND` environment variable  
- **Config**: Add `with_backend_override()` method
- **Config**: Update `load_with_overrides()` signature to include backend
- **Info**: Display backend in `murmur info` output
- **Tests**: 4 new unit tests for backend override logic

## Test plan

- [x] All 111 murmur-core tests pass
- [x] cargo fmt / clippy clean
- [x] Build succeeds

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--backend` CLI option to select backend at runtime
  * Added `MURMUR_BACKEND` environment variable support for backend configuration
  * Backend selection now displayed in agent settings output

* **Chores**
  * Removed legacy metadata fields from worktree configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->