### PR TITLE
docs: add example config with per-agent-type backend selection

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,43 @@
+# Murmur Configuration Example
+#
+# This configuration demonstrates per-agent-type backend and model selection.
+# Copy to ~/.config/murmur/config.toml to use.
+
+[agent]
+# Global defaults - used when no per-type config specified
+backend = "claude"
+model = "claude-opus-4-5-20251101"
+
+# Paths to AI coding tool executables
+claude_path = "claude"
+cursor_path = "cursor-agent"
+
+# Per-agent-type configuration
+# Each type can have its own backend and model override
+
+[agent.implement]
+# Use the best model for coding tasks
+backend = "claude"
+model = "claude-opus-4-5-20251101"
+
+[agent.test]
+# Can use cheaper backend for test generation
+backend = "cursor"
+# model uses cursor's default
+
+[agent.review]
+# Use high-end model for thorough code review
+backend = "claude"
+model = "claude-opus-4-5-20251101"
+
+[agent.coordinator]
+# Coordinator tasks are simpler - use unlimited/cheaper backend
+backend = "cursor"
+# model uses cursor's default
+
+[workflow]
+# Automatically push branch after agent completion
+auto_push = true
+
+# Automatically create PR after agent completion
+auto_pr = true


### PR DESCRIPTION
## Summary

Add `config.example.toml` demonstrating the per-agent-type configuration for backend and model selection (Phase 4.5).

### Configuration Strategy

Based on user requirements:
- **Claude Opus 4.5** for `implement` (coding) and `review` agents - best quality for critical tasks
- **Cursor** for `test` and `coordinator` agents - cheaper/unlimited for simpler tasks

### Example Config

```toml
[agent]
backend = "claude"
model = "claude-opus-4-5-20251101"
claude_path = "claude"
cursor_path = "cursor-agent"

[agent.implement]
backend = "claude"
model = "claude-opus-4-5-20251101"  # Best model for coding

[agent.test]
backend = "cursor"  # Cheaper for test generation

[agent.review]
backend = "claude"
model = "claude-opus-4-5-20251101"  # High-end for review quality

[agent.coordinator]
backend = "cursor"  # Unlimited for orchestration tasks
```

### Usage

Copy to `~/.config/murmur/config.toml` to use.

## Test plan

- [x] TOML syntax valid
- [x] Comments explain each section

Related to #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)