### PR TITLE
refactor(db): remove .murmur-worktree.toml, migrate to SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 
 # Murmuration cache
 .murmur/
+
+# Legacy worktree metadata (now stored in SQLite database)
+.murmur-worktree.toml

--- a/murmur-db/src/connection.rs
+++ b/murmur-db/src/connection.rs
@@ -189,6 +189,18 @@ impl Database {
                 .execute("ALTER TABLE worktrees ADD COLUMN main_repo_path TEXT", [])?;
         }
 
+        // Migrate existing worktrees table to add base_commit column if it doesn't exist
+        let has_base_commit = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('worktrees') WHERE name='base_commit'",
+            [],
+            |row| row.get::<_, i32>(0),
+        )?;
+
+        if has_base_commit == 0 {
+            self.conn
+                .execute("ALTER TABLE worktrees ADD COLUMN base_commit TEXT", [])?;
+        }
+
         // Create issue_states table for tracking GitHub issue status
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS issue_states (

--- a/murmur-db/src/models.rs
+++ b/murmur-db/src/models.rs
@@ -190,6 +190,9 @@ pub struct WorktreeRecord {
     /// Path to the main repository (for finding git repo when worktree is cached)
     pub main_repo_path: Option<String>,
 
+    /// Base commit SHA at worktree creation (replaces .murmur-worktree.toml base_commit)
+    pub base_commit: Option<String>,
+
     /// Status: active, completed, abandoned, stale
     pub status: String,
 
@@ -211,6 +214,7 @@ impl WorktreeRecord {
             issue_number: None,
             agent_run_id: None,
             main_repo_path: None,
+            base_commit: None,
             status: "active".to_string(),
             created_at: now,
             updated_at: now,
@@ -232,6 +236,12 @@ impl WorktreeRecord {
     /// Set the main repository path for this worktree
     pub fn with_main_repo_path(mut self, main_repo_path: impl Into<String>) -> Self {
         self.main_repo_path = Some(main_repo_path.into());
+        self
+    }
+
+    /// Set the base commit SHA for this worktree
+    pub fn with_base_commit(mut self, base_commit: impl Into<String>) -> Self {
+        self.base_commit = Some(base_commit.into());
         self
     }
 


### PR DESCRIPTION
## Summary

Migrate worktree metadata storage from TOML files to SQLite database, eliminating merge conflicts and consolidating metadata in a single source of truth.

### Changes

**Database Schema:**
- Add `base_commit` column to `worktrees` table with automatic migration

**Models:**
- Add `base_commit` field to `WorktreeRecord`
- Add `with_base_commit()` builder method

**Repository:**
- Update all worktrees repository queries to include `base_commit`

**CLI Commands:**
- `murmur status`: Use database to get branch names instead of loading TOML
- `murmur work`: Remove TOML save calls (database already tracks metadata)
- `murmur worktree clean`: Use database for branch names during cleanup

**Gitignore:**
- Add `.murmur-worktree.toml` to prevent legacy files from being committed

### Problem Solved

Previously, `.murmur-worktree.toml` files were created in each worktree and committed to branches. This caused:
1. Merge conflicts when rebasing/merging branches
2. Data duplication between TOML files and SQLite database
3. Polluted git history with metadata files

### Migration Approach

The migration is backward-compatible:
- New worktrees use database-only storage
- CLI commands now query database instead of TOML
- WorktreePool still handles filesystem cache management (acceptable)
- Existing TOML files are ignored via .gitignore

## Test plan

- [x] All 52 murmur-db tests pass
- [x] All 114 murmur-core tests pass
- [x] cargo clippy passes
- [x] cargo fmt passes
- [x] Release build succeeds

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)