### PR TITLE
feat(cli): add murmur agent start --type command

### DIFF
--- a/murmur-cli/src/commands/agent.rs
+++ b/murmur-cli/src/commands/agent.rs
@@ -57,7 +57,7 @@ impl StartArgs {
     pub async fn execute(&self, verbose: bool, config: &Config) -> anyhow::Result<()> {
         // Resolve to absolute path
         let workdir = if self.workdir.is_absolute() {
-            self.workdir.clone()
+            self.workdir.to_path_buf()
         } else {
             std::env::current_dir()?.join(&self.workdir)
         };


### PR DESCRIPTION
## Summary

Adds `murmur agent start` command to spawn typed agents with specialized prompts and behaviors:
- `--type/-t`: specify agent type (implement, test, review, coordinator)
- `--dry-run`: preview configuration without spawning
- `--workdir/-d`: specify working directory

## Example Usage

```bash
murmur agent start --type implement "Add feature X"
murmur a start -t test "Write tests for auth module"
murmur a start -t review "Review the changes" --dry-run
```

## Test Plan

- [x] cargo fmt passes
- [x] cargo clippy passes with no warnings
- [x] cargo test passes (179 tests)
- [x] Command successfully starts agents with different types
- [x] Dry-run mode works correctly

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new `agent` command (alias: `a`) to the CLI for starting AI agents with customizable agent type, prompt, and working directory options.
* Supports dry-run mode to preview agent configuration and intended actions without spawning processes.
* Includes verbose logging for detailed diagnostic output during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->