### PR TITLE
Workflow supervisor: wait for CodeRabbitAI reviews before merging

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -78,6 +78,30 @@ auto_pr = true
 # Default: false
 auto_review_loop = false
 
+# Bot review waiting configuration
+# Wait for automated code review bots before proceeding
+[workflow.reviews]
+# Bot usernames to wait for before auto-merge (e.g., ["coderabbitai[bot]", "github-actions[bot]"])
+# Default: [] (no bots to wait for)
+wait_for_bots = ["coderabbitai[bot]"]
+
+# Timeout in minutes (0 = no timeout, wait indefinitely)
+# Default: 0
+bot_review_timeout = 30
+
+# Action on timeout: "merge_anyway", "skip", "fail"
+#   - merge_anyway: Proceed with merge despite missing reviews
+#   - skip: Leave PR open without merging
+#   - fail: Fail the workflow with an error
+# Default: "merge_anyway"
+timeout_action = "merge_anyway"
+
+# Require APPROVED state from bots
+# If false, any review state (COMMENTED, APPROVED, etc.) counts as reviewed
+# If true, only APPROVED reviews count
+# Default: false
+require_bot_approval = false
+
 # Example configurations for different use cases:
 
 # ============================================================================

--- a/murmur-cli/src/commands/work.rs
+++ b/murmur-cli/src/commands/work.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use murmur_core::workflow::{TestFramework, TestRunner};
 use murmur_core::{
     AgentFactory, AgentSpawner, AgentType, BranchingOptions, Config, GitRepo, OutputStreamer,
-    Secrets, TddPhase, TddWorkflow, WorktreeOptions,
+    ReviewConfig, Secrets, TddPhase, TddWorkflow, TimeoutAction, WorktreeOptions,
 };
 use murmur_db::{
     models::{AgentRun, ConversationLog, WorktreeRecord},
@@ -13,6 +13,7 @@ use murmur_db::{
     Database,
 };
 use murmur_github::{DependencyStatus, GitHubClient, IssueDependencies, IssueState};
+use std::time::{Duration, Instant};
 
 /// Work on a GitHub issue
 #[derive(Args, Debug)]
@@ -55,6 +56,17 @@ pub struct WorkArgs {
     /// Maximum iterations for Implement->VerifyGreen loop - only with --tdd
     #[arg(long, default_value = "3")]
     pub max_iterations: u32,
+}
+
+/// Result of waiting for bot reviews
+#[derive(Debug)]
+pub enum BotReviewResult {
+    /// All configured bots have reviewed
+    AllReviewed,
+    /// Timeout reached with pending bots
+    Timeout(Vec<String>),
+    /// No bots configured to wait for
+    NoBots,
 }
 
 impl WorkArgs {
@@ -914,7 +926,7 @@ impl WorkArgs {
         issue: &murmur_github::Issue,
         verbose: bool,
         no_emoji: bool,
-        _client: &GitHubClient,
+        client: &GitHubClient,
     ) -> anyhow::Result<()> {
         use std::process::Command;
 
@@ -1198,7 +1210,60 @@ impl WorkArgs {
             None
         };
 
-        // Step 6: Monitor for review feedback if configured and PR was created
+        // Step 6: Wait for bot reviews if configured and PR was created
+        if let Some(pr_num) = pr_number {
+            if !config.workflow.reviews.wait_for_bots.is_empty() {
+                println!();
+                println!(
+                    "{}  Waiting for bot reviews before merge...",
+                    emoji(no_emoji, "🤖", "[BOT]")
+                );
+
+                match wait_for_bot_reviews(client, pr_num, &config.workflow.reviews, no_emoji).await
+                {
+                    Ok(BotReviewResult::AllReviewed) => {
+                        println!(
+                            "{} All configured bots have reviewed",
+                            emoji(no_emoji, "✅", "[OK]")
+                        );
+                    }
+                    Ok(BotReviewResult::Timeout(pending)) => {
+                        println!(
+                            "{}  Timeout waiting for reviews from: {:?}",
+                            emoji(no_emoji, "⏱️", "[TIMEOUT]"),
+                            pending
+                        );
+                        match config.workflow.reviews.timeout_action {
+                            TimeoutAction::MergeAnyway => {
+                                println!("  Action: merge_anyway - proceeding despite timeout");
+                            }
+                            TimeoutAction::Skip => {
+                                println!("  Action: skip - leaving PR open without merging");
+                            }
+                            TimeoutAction::Fail => {
+                                println!("  Action: fail - workflow failed due to timeout");
+                                return Err(anyhow::anyhow!(
+                                    "Bot review timeout: pending reviews from {:?}",
+                                    pending
+                                ));
+                            }
+                        }
+                    }
+                    Ok(BotReviewResult::NoBots) => {
+                        // Should not happen since we check wait_for_bots.is_empty() above
+                    }
+                    Err(e) => {
+                        println!(
+                            "{}  Error checking bot reviews: {}",
+                            emoji(no_emoji, "⚠️", "[WARN]"),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        // Step 7: Monitor for review feedback if configured and PR was created
         if config.workflow.auto_review_loop && pr_number.is_some() {
             println!();
             println!(
@@ -1210,6 +1275,89 @@ impl WorkArgs {
         }
 
         Ok(())
+    }
+}
+
+/// Wait for configured bot reviews on a PR
+///
+/// Polls the PR reviews at 30-second intervals until either:
+/// - All configured bots have reviewed (any state, or APPROVED if require_bot_approval is true)
+/// - The timeout is reached
+/// - An error occurs
+async fn wait_for_bot_reviews(
+    client: &GitHubClient,
+    pr_number: u64,
+    config: &ReviewConfig,
+    no_emoji: bool,
+) -> anyhow::Result<BotReviewResult> {
+    if config.wait_for_bots.is_empty() {
+        return Ok(BotReviewResult::NoBots);
+    }
+
+    let start = Instant::now();
+    let timeout = if config.bot_review_timeout > 0 {
+        Some(Duration::from_secs(config.bot_review_timeout * 60))
+    } else {
+        None // No timeout - wait indefinitely
+    };
+
+    let poll_interval = Duration::from_secs(30);
+
+    loop {
+        // Fetch current reviews
+        let reviews = client.get_pr_reviews(pr_number).await?;
+
+        // Check which bots have reviewed
+        let mut pending_bots = config.wait_for_bots.clone();
+
+        for review in &reviews {
+            // Check if this review is from a configured bot
+            if let Some(pos) = pending_bots.iter().position(|b| b == &review.author) {
+                // If require_bot_approval is true, only count APPROVED reviews
+                if config.require_bot_approval {
+                    if review.state.contains("Approved") || review.state == "APPROVED" {
+                        pending_bots.remove(pos);
+                    }
+                } else {
+                    // Any review state counts
+                    pending_bots.remove(pos);
+                }
+            }
+        }
+
+        // All bots have reviewed
+        if pending_bots.is_empty() {
+            return Ok(BotReviewResult::AllReviewed);
+        }
+
+        // Check timeout
+        if let Some(timeout_duration) = timeout {
+            if start.elapsed() > timeout_duration {
+                return Ok(BotReviewResult::Timeout(pending_bots));
+            }
+        }
+
+        // Display status
+        println!(
+            "  {} Waiting for reviews from: {:?}",
+            emoji(no_emoji, "⏳", "[WAIT]"),
+            pending_bots
+        );
+
+        // Display existing reviews from configured bots
+        for review in &reviews {
+            if config.wait_for_bots.contains(&review.author) {
+                println!(
+                    "    {} {}: {}",
+                    emoji(no_emoji, "📝", "[REV]"),
+                    review.author,
+                    review.state
+                );
+            }
+        }
+
+        // Wait before next poll
+        tokio::time::sleep(poll_interval).await;
     }
 }
 

--- a/murmur-core/src/config.rs
+++ b/murmur-core/src/config.rs
@@ -164,6 +164,51 @@ impl AgentConfig {
     }
 }
 
+/// Action to take when bot review timeout is reached
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeoutAction {
+    /// Merge the PR anyway
+    MergeAnyway,
+    /// Skip the merge, leave PR open
+    Skip,
+    /// Fail with an error
+    Fail,
+}
+
+impl Default for TimeoutAction {
+    fn default() -> Self {
+        Self::MergeAnyway
+    }
+}
+
+impl std::fmt::Display for TimeoutAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimeoutAction::MergeAnyway => write!(f, "merge_anyway"),
+            TimeoutAction::Skip => write!(f, "skip"),
+            TimeoutAction::Fail => write!(f, "fail"),
+        }
+    }
+}
+
+/// Configuration for waiting on bot reviews before auto-merge
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ReviewConfig {
+    /// Bot usernames to wait for (e.g., ["coderabbitai[bot]", "github-actions[bot]"])
+    pub wait_for_bots: Vec<String>,
+
+    /// Timeout in minutes (0 = no timeout, wait indefinitely)
+    pub bot_review_timeout: u64,
+
+    /// Action on timeout: "merge_anyway", "skip", "fail"
+    pub timeout_action: TimeoutAction,
+
+    /// Require APPROVED state from bots (false = just needs to comment)
+    pub require_bot_approval: bool,
+}
+
 /// Workflow automation configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -179,6 +224,9 @@ pub struct WorkflowConfig {
 
     /// Re-spawn agent to address review feedback (opt-in)
     pub auto_review_loop: bool,
+
+    /// Configuration for waiting on bot reviews before auto-merge
+    pub reviews: ReviewConfig,
 }
 
 impl Default for WorkflowConfig {
@@ -188,6 +236,7 @@ impl Default for WorkflowConfig {
             auto_push: true,
             auto_pr: true,
             auto_review_loop: false,
+            reviews: ReviewConfig::default(),
         }
     }
 }
@@ -741,5 +790,108 @@ model = "claude-haiku-4-20250514"
 
         // Invalid backend should be ignored, keeping the default
         assert_eq!(config.agent.backend, Backend::Claude);
+    }
+
+    #[test]
+    fn test_review_config_defaults() {
+        let config = ReviewConfig::default();
+        assert!(config.wait_for_bots.is_empty());
+        assert_eq!(config.bot_review_timeout, 0);
+        assert_eq!(config.timeout_action, TimeoutAction::MergeAnyway);
+        assert!(!config.require_bot_approval);
+    }
+
+    #[test]
+    fn test_timeout_action_default() {
+        assert_eq!(TimeoutAction::default(), TimeoutAction::MergeAnyway);
+    }
+
+    #[test]
+    fn test_timeout_action_display() {
+        assert_eq!(TimeoutAction::MergeAnyway.to_string(), "merge_anyway");
+        assert_eq!(TimeoutAction::Skip.to_string(), "skip");
+        assert_eq!(TimeoutAction::Fail.to_string(), "fail");
+    }
+
+    #[test]
+    fn test_parse_review_config() {
+        let toml = r#"
+[workflow]
+auto_commit = true
+
+[workflow.reviews]
+wait_for_bots = ["coderabbitai[bot]", "github-actions[bot]"]
+bot_review_timeout = 30
+timeout_action = "skip"
+require_bot_approval = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.workflow.reviews.wait_for_bots.len(), 2);
+        assert!(config
+            .workflow
+            .reviews
+            .wait_for_bots
+            .contains(&"coderabbitai[bot]".to_string()));
+        assert!(config
+            .workflow
+            .reviews
+            .wait_for_bots
+            .contains(&"github-actions[bot]".to_string()));
+        assert_eq!(config.workflow.reviews.bot_review_timeout, 30);
+        assert_eq!(config.workflow.reviews.timeout_action, TimeoutAction::Skip);
+        assert!(config.workflow.reviews.require_bot_approval);
+    }
+
+    #[test]
+    fn test_parse_timeout_action_variants() {
+        let toml_merge = r#"
+[workflow.reviews]
+timeout_action = "merge_anyway"
+"#;
+        let config: Config = toml::from_str(toml_merge).unwrap();
+        assert_eq!(
+            config.workflow.reviews.timeout_action,
+            TimeoutAction::MergeAnyway
+        );
+
+        let toml_skip = r#"
+[workflow.reviews]
+timeout_action = "skip"
+"#;
+        let config: Config = toml::from_str(toml_skip).unwrap();
+        assert_eq!(config.workflow.reviews.timeout_action, TimeoutAction::Skip);
+
+        let toml_fail = r#"
+[workflow.reviews]
+timeout_action = "fail"
+"#;
+        let config: Config = toml::from_str(toml_fail).unwrap();
+        assert_eq!(config.workflow.reviews.timeout_action, TimeoutAction::Fail);
+    }
+
+    #[test]
+    fn test_workflow_config_includes_reviews() {
+        let config = WorkflowConfig::default();
+        // Default reviews config should be empty
+        assert!(config.reviews.wait_for_bots.is_empty());
+    }
+
+    #[test]
+    fn test_parse_empty_reviews_section() {
+        let toml = r#"
+[workflow]
+auto_commit = true
+
+[workflow.reviews]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        // Should use defaults
+        assert!(config.workflow.reviews.wait_for_bots.is_empty());
+        assert_eq!(config.workflow.reviews.bot_review_timeout, 0);
+        assert_eq!(
+            config.workflow.reviews.timeout_action,
+            TimeoutAction::MergeAnyway
+        );
+        assert!(!config.workflow.reviews.require_bot_approval);
     }
 }

--- a/murmur-core/src/lib.rs
+++ b/murmur-core/src/lib.rs
@@ -17,7 +17,7 @@ pub use agent::{
     OutputStreamer, PrintHandler, PromptBuilder, PromptContext, ReviewAgent, StreamHandler,
     StreamMessage, TestAgent, TypedAgent,
 };
-pub use config::{AgentConfig, Config};
+pub use config::{AgentConfig, Config, ReviewConfig, TimeoutAction};
 pub use error::{Error, Result};
 pub use git::{
     cached_repo_path, clone_repo, default_cache_dir, default_repos_cache_dir, fetch_repo,


### PR DESCRIPTION
Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow configuration for bot-based code review handling
  * Customize which bots to wait for before proceeding with auto-merge
  * Configure timeout durations and fallback actions when bots don't respond
  * Control whether bot approvals are strictly required for merging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->